### PR TITLE
remove fullscreen-mode

### DIFF
--- a/recipes/fullscreen-mode
+++ b/recipes/fullscreen-mode
@@ -1,1 +1,0 @@
-(fullscreen-mode :fetcher github :repo "ryantm/fullscreen-mode")


### PR DESCRIPTION
fullscreen-mode does not seem to work anymore, and I am told it is not
needed in later versions of Emacs anyway, so I would like to remove it
from these package archives.

I am the author and maintainer of fullscreen-mode.