### PR TITLE
fasd-shell: quickly cd with fasd and ido in shell-mode

### DIFF
--- a/recipes/fasd-shell
+++ b/recipes/fasd-shell
@@ -1,0 +1,3 @@
+(fasd-shell
+ :url "https://gitlab.com/emacs-stuff/fasd-shell.git"
+ :fetcher git)


### PR DESCRIPTION
Hi there,
here's a recipe for this utility: https://gitlab.com/emacs-stuff/fasd-shell
Useful for those who want to cd quickly with the fasd command-line utility, using ido, in shell-mode.
My tests (emacs -q, make recipe, package-install-file) say everythin's fine !

cheers