### PR TITLE
add recipe for pylookup

### DIFF
--- a/recipes/pylookup
+++ b/recipes/pylookup
@@ -1,0 +1,1 @@
+(pylookup :fetcher github :repo "tsgates/pylookup" :files ("pylookup.el" "pylookup.py" "makefile"))


### PR DESCRIPTION
`pylookup` is a tool that an emacs user to search Python HTML documentation either online or offline. This is the link to project page: https://github.com/tsgates/pylookup.

I'm not the author nor the maintainer, just a user of this package. I have reached the author and he's willing to add a recipe for this package(as https://github.com/tsgates/pylookup/issues/31).  I'll be happy to take care of any issue that comes up.