### PR TITLE
first cut lilypond-mode package

### DIFF
--- a/recipes/lilypond-mode
+++ b/recipes/lilypond-mode
@@ -1,0 +1,4 @@
+(lilypond-mode
+ :fetcher git
+ :url "git://git.savannah.gnu.org/lilypond.git"
+ :files ("elisp/*.el")))

--- a/recipes/lilypond-mode
+++ b/recipes/lilypond-mode
@@ -1,4 +1,4 @@
 (lilypond-mode
  :fetcher git
  :url "git://git.savannah.gnu.org/lilypond.git"
- :files ("elisp/*.el")))
+ :files ("elisp/*.el"))


### PR DESCRIPTION
Hello,

Long time user; first time contributor here. This pull request is to add a package for lilypond--the excellent music engraving software. The software ships with a lilypond mode. This package points to that (http://git.savannah.gnu.org/gitweb/?p=lilypond.git;a=tree;f=elisp;h=f7f2919a4a4a9dce15641031f9aed12daba5d188;hb=master).

The package build seems to fetch the whole lilypond source (maybe more than you want to pull down), however I couldn't figure out how to make Melpa be more selective in fetching only the elisp directory.

I will be emailing the development contact with a link to this PR so that they can follow along and opine.

Package appears to load via package-load-file and run okay.

Thanks for all your hard work in making emacs a fun place!