### PR TITLE
remove recipe for deprecated packed-git

### DIFF
--- a/recipes/packed-git
+++ b/recipes/packed-git
@@ -1,1 +1,0 @@
-(packed-git :repo "tarsius/packed" :fetcher github :files ("packed-git.el"))


### PR DESCRIPTION
See https://github.com/tarsius/packed/commit/ceffaa5.