### PR TITLE
Fix :fetcher of recipes that used a string as value

### DIFF
--- a/recipes/auto-dim-other-buffers
+++ b/recipes/auto-dim-other-buffers
@@ -1,1 +1,1 @@
-(auto-dim-other-buffers :fetcher "github" :repo "mina86/auto-dim-other-buffers.el")
+(auto-dim-other-buffers :fetcher github :repo "mina86/auto-dim-other-buffers.el")

--- a/recipes/bbcode-mode
+++ b/recipes/bbcode-mode
@@ -1,3 +1,1 @@
-(bbcode-mode
- :fetcher "github"
- :repo "ejmr/bbcode-mode")
+(bbcode-mode :fetcher github :repo "ejmr/bbcode-mode")

--- a/recipes/codic
+++ b/recipes/codic
@@ -1,2 +1,3 @@
-(codic :fetcher "github" :repo "syohex/emacs-codic"
+(codic :fetcher github
+       :repo "syohex/emacs-codic"
        :files ("*.el" ("dict" "dict/*.csv")))

--- a/recipes/company-tern
+++ b/recipes/company-tern
@@ -1,1 +1,1 @@
-(company-tern :fetcher "github" :repo "proofit404/company-tern")
+(company-tern :fetcher github :repo "proofit404/company-tern")

--- a/recipes/control-mode
+++ b/recipes/control-mode
@@ -1,1 +1,1 @@
-(control-mode :fetcher "github" :repo "stephendavidmarsh/control-mode")
+(control-mode :fetcher github :repo "stephendavidmarsh/control-mode")

--- a/recipes/dvorak-mode
+++ b/recipes/dvorak-mode
@@ -1,3 +1,1 @@
-(dvorak-mode
- :fetcher "github"
- :repo "proofit404/dvorak-mode")
+(dvorak-mode :fetcher github :repo "proofit404/dvorak-mode")

--- a/recipes/edbi-sqlite
+++ b/recipes/edbi-sqlite
@@ -1,4 +1,4 @@
 (edbi-sqlite
- :fetcher "github"
+ :fetcher github
  :repo "proofit404/edbi-sqlite"
  :old-names (edbi-sqlite3))

--- a/recipes/edit-indirect
+++ b/recipes/edit-indirect
@@ -1,1 +1,1 @@
-(edit-indirect :fetcher "github" :repo "Fanael/edit-indirect")
+(edit-indirect :fetcher github :repo "Fanael/edit-indirect")

--- a/recipes/emacsc
+++ b/recipes/emacsc
@@ -1,4 +1,4 @@
 (emacsc
- :fetcher "github"
+ :fetcher github
  :repo "knu/emacsc"
  :files ("lisp/*.el" "bin"))

--- a/recipes/grunt
+++ b/recipes/grunt
@@ -1,1 +1,1 @@
-(grunt :fetcher "github" :repo "gempesaw/grunt.el")
+(grunt :fetcher github :repo "gempesaw/grunt.el")

--- a/recipes/helm-perldoc
+++ b/recipes/helm-perldoc
@@ -1,2 +1,3 @@
-(helm-perldoc :fetcher "github" :repo "syohex/emacs-helm-perldoc"
+(helm-perldoc :fetcher github
+	      :repo "syohex/emacs-helm-perldoc"
               :files ("*.el" "*.pl"))

--- a/recipes/helm-pydoc
+++ b/recipes/helm-pydoc
@@ -1,4 +1,4 @@
 (helm-pydoc
- :fetcher "github"
+ :fetcher github
  :repo "syohex/emacs-helm-pydoc"
  :files ("*.el" "*.py"))

--- a/recipes/highlight-defined
+++ b/recipes/highlight-defined
@@ -1,1 +1,1 @@
-(highlight-defined :fetcher "github" :repo "Fanael/highlight-defined")
+(highlight-defined :fetcher github :repo "Fanael/highlight-defined")

--- a/recipes/ido-vertical-mode
+++ b/recipes/ido-vertical-mode
@@ -1,1 +1,1 @@
-(ido-vertical-mode :fetcher "github" :repo "gempesaw/ido-vertical-mode.el")
+(ido-vertical-mode :fetcher github :repo "gempesaw/ido-vertical-mode.el")

--- a/recipes/pyenv-mode
+++ b/recipes/pyenv-mode
@@ -1,3 +1,1 @@
-(pyenv-mode
- :fetcher "github"
- :repo "proofit404/pyenv-mode")
+(pyenv-mode :fetcher github :repo "proofit404/pyenv-mode")

--- a/recipes/quickref
+++ b/recipes/quickref
@@ -1,1 +1,1 @@
-(quickref :fetcher "github" :repo "pd/quickref.el")
+(quickref :fetcher github :repo "pd/quickref.el")

--- a/recipes/virtualenvwrapper
+++ b/recipes/virtualenvwrapper
@@ -1,3 +1,1 @@
-(virtualenvwrapper
-  :repo "porterjamesj/virtualenvwrapper.el"
-  :fetcher "github")
+(virtualenvwrapper :fetcher github :repo "porterjamesj/virtualenvwrapper.el")

--- a/recipes/vs-emulation-mode
+++ b/recipes/vs-emulation-mode
@@ -1,1 +1,1 @@
-(vs-emulation-mode :fetcher "github" :repo "Fanael/vs-emulation-mode")
+(vs-emulation-mode :fetcher github :repo "Fanael/vs-emulation-mode")


### PR DESCRIPTION
While comparing the sets of Emacswiki packages on Melpa and the Emacsmirror (more on that later), I came across these errors. 