### PR TITLE
Add history - History utility for source code navigation

### DIFF
--- a/recipes/history
+++ b/recipes/history
@@ -1,2 +1,5 @@
-(history :repo "boyw165/history" :fetcher github)
+(history
+ :fetcher github
+ :repo "boyw165/history"
+ :files ("*.el" "images" "images/*.xpm" "images/*.png"))
 

--- a/recipes/history
+++ b/recipes/history
@@ -1,0 +1,2 @@
+(history :repo "boyw165/history" :fetcher github)
+


### PR DESCRIPTION
Hi MELPA team,

Here's a recipe for this utility: https://github.com/boyw165/history
This tool is for source code navigation. It's similar to `pop-global-mark` but more powerful. You can go through the whole history without losing them. Actually, `pop-global-mark` will use the latest record but also discard it. But this tool will preserve all the history and smartly ignored killed buffers or invalid symbol string.

It's really convenient to use `his-add-history`, `his-prev-history` and `his-next-history` instead of built-in old way.

Cheers