### PR TITLE
add flymake-vala

### DIFF
--- a/recipes/flymake-vala
+++ b/recipes/flymake-vala
@@ -1,0 +1,1 @@
+(flymake-vala :repo "daniellawrence/flymake-vala" :fetcher github)


### PR DESCRIPTION
This is a flymake for the [Vala language](https://wiki.gnome.org/Projects/Vala).

[flymake-vala](https://github.com/daniellawrence/flymake-vala) is based on [flymake-ruby](https://github.com/purcell/flymake-ruby) and built on top of [flymake-easy](https://github.com/purcell/flymake-easy/)
