### PR TITLE
Add recipe for dyalog-mode.

### DIFF
--- a/recipes/dyalog-mode
+++ b/recipes/dyalog-mode
@@ -1,0 +1,4 @@
+(dyalog-mode
+ :fetcher hg
+ :url "https://bitbucket.org/harsman/dyalog-mode/"
+ :files (:defaults "Emacs.apl"))


### PR DESCRIPTION
Please consider adding dyalog-mode to MELPA.

Dyalog mode is a major mode for editing Dyalog APL (http://dyalog.com/) source code, it lives here: 

https://bitbucket.org/harsman/dyalog-mode

I am the author and maintainer.