### PR TITLE
Add recipe for vim-empty-lines-mode

### DIFF
--- a/recipes/vim-empty-lines-mode
+++ b/recipes/vim-empty-lines-mode
@@ -1,0 +1,2 @@
+(vim-empty-lines-mode :url "https://github.com/jmickelin/vim-empty-lines-mode"
+                      :fetcher git)


### PR DESCRIPTION
I've written a package called vim-empty-lines-mode that defines a minor mode that displays a customizable string (defaulting to "~") instead of the blank lines following the end-of-buffer. It is intended to emulate the way vim indicates empty lines at the end of a file.

Direct link to repository: https://github.com/jmickelin/vim-empty-lines-mode