### PR TITLE
Add recipe for aproject

### DIFF
--- a/recipes/aproject
+++ b/recipes/aproject
@@ -1,0 +1,3 @@
+(aproject
+ :repo "vietor/aproject"
+ :fetcher github)


### PR DESCRIPTION
A simple project tool for Emacs.

This library allows the user to use Emacs on multiple projects.
Any project has it's ".aproject" dirctory for store some files, like: session, desktop, etc.