### PR TITLE
fix ibuffer-git recipe

### DIFF
--- a/recipes/ibuffer-git
+++ b/recipes/ibuffer-git
@@ -1,4 +1,1 @@
-(ibuffer-git
-  :repo "jrockway/ibuffer-git"
-  :fetcher github
-  :file ("ibuffer-git.el"))
+(ibuffer-git :fetcher github :repo "jrockway/ibuffer-git")


### PR DESCRIPTION
Since you told me that there was some code which could be used to detect unnecessary uses of `:files` I have stopped fixing these things manually. But this one is different, it fails to do the unnecessary thing and uses `:file` (singular) instead. (By the way that's the only such mistake across all recipes).