### PR TITLE
Add emacsshot

### DIFF
--- a/recipes/emacsshot
+++ b/recipes/emacsshot
@@ -1,0 +1,1 @@
+(emacsshot :fetcher github :repo "marcowahl/emacsshot")


### PR DESCRIPTION
emacsshot.el --- Snapshot a frame or window from within Emacs

https://github.com/marcowahl/emacsshot

Compared to screenshot.el emacsshot.el is restricted to take shots of Emacs.  Further it does not involve the mouse and can take not only shots of Emacs-frames but also shots of Emacs-windows.

I'm the contributor and maintainer of emacsshot.


Best regards!