### PR TITLE
Recipe for pdf-tools

### DIFF
--- a/recipes/pdf-tools
+++ b/recipes/pdf-tools
@@ -1,10 +1,7 @@
-(pdf-tools :fetcher github
-           :repo "politza/pdf-tools"
-           :files ("lisp/*.el"
-                   "README"
-                   ("server"
-                    "Makefile.am"
-                    "autogen.sh"
-                    "configure.ac"
-                    ("tests" "tests/Makefile.am")
-                    ("src" "src/*"))))
+(pdf-tools
+ :fetcher github
+ :repo "politza/pdf-tools"
+ :files ("lisp/*.el"
+         "README"
+         "Makefile"
+         ("server" "server/*")))

--- a/recipes/pdf-tools
+++ b/recipes/pdf-tools
@@ -4,4 +4,5 @@
  :files ("lisp/*.el"
          "README"
          "Makefile"
-         ("server" "server/*")))
+         ("server" "server/*")
+         (:exclude "lisp/tablist.el" "lisp/tablist-filter.el")))

--- a/recipes/pdf-tools
+++ b/recipes/pdf-tools
@@ -3,6 +3,6 @@
  :repo "politza/pdf-tools"
  :files ("lisp/*.el"
          "README"
-         "Makefile"
-         ("server" "server/*")
+         ("build" "Makefile")
+         ("build" "server")
          (:exclude "lisp/tablist.el" "lisp/tablist-filter.el")))

--- a/recipes/pdf-tools
+++ b/recipes/pdf-tools
@@ -1,0 +1,10 @@
+(pdf-tools :fetcher github
+           :repo "politza/pdf-tools"
+           :files ("lisp/*.el"
+                   "README"
+                   ("server"
+                    "Makefile.am"
+                    "autogen.sh"
+                    "configure.ac"
+                    ("tests" "tests/Makefile.am")
+                    ("src" "src/*"))))

--- a/recipes/tablist
+++ b/recipes/tablist
@@ -1,0 +1,3 @@
+(tablist
+ :fetcher github
+ :repo "politza/tablist")

--- a/recipes/tablist
+++ b/recipes/tablist
@@ -1,3 +1,5 @@
 (tablist
  :fetcher github
- :repo "politza/tablist")
+ :repo "politza/pdf-tools"
+ :files ("lisp/tablist.el"
+         "lisp/tablist-filter.el"))


### PR DESCRIPTION
        PDF Tools is, among other things, a replacement of DocView for
        PDF  files.  The  key  difference   is,  that  pages  are  not
        prerendered by e.g. ghostscript and stored in the file-system,
        but rather created on-demand and stored in memory.

        This rendering  is performed by  a special library  named, for
        whatever   reason,   poppler,    running   inside   a   server
        programm. This programm is called  epdfinfo and it’s job is it
        to  successively  read requests  from  Emacs  and produce  the
        proper results, i.e. the PNG image of a PDF page.

        Actually,  displaying  PDF  files  is just  one  part  of  PDF
        Tools.  Since  poppler  can  provide  us  with  all  kinds  of
        informations about a  document and is also able  to modify it,
        there is a lot more we can do with it.

I'm the maintainer of this project at https://github.com/politza/pdf-tools .
