### PR TITLE
Adding a recipe for llvm-mode.

### DIFF
--- a/recipes/llvm-mode
+++ b/recipes/llvm-mode
@@ -1,0 +1,5 @@
+(llvm-mode
+ :url "http://llvm.org/git/llvm"
+ :files ("utils/emacs/llvm-mode.el"
+         "utils/emacs/tablegen-mode.el")
+ :fetcher git)


### PR DESCRIPTION
Adding a recipe for llvm-mode, which allows editing LLVM IR files, and tablegen-mode, which allows editing LLVM's table files.

This is a second attempt at #2177, having fixed upstream the issues mentioned there.