### PR TITLE
Add recipe for narrowed-page-navigation

### DIFF
--- a/recipes/narrowed-page-navigation
+++ b/recipes/narrowed-page-navigation
@@ -1,0 +1,3 @@
+(narrowed-page-navigation
+ :fetcher github
+ :repo "david-christiansen/narrowed-page-navigation")


### PR DESCRIPTION
This minor mode gives keybindings for navigating from page to page while narrowed. It is intended to be used in live-coding or research talks that focus on Emacs-based proof assistants.

Repository: https://github.com/david-christiansen/narrowed-page-navigation

I am the package author.