### PR TITLE
Add recipe for the in-Emacs slide show package live-code-talks

### DIFF
--- a/recipes/live-code-talks
+++ b/recipes/live-code-talks
@@ -1,0 +1,3 @@
+(live-code-talks
+ :fetcher github
+ :repo "david-christiansen/live-code-talks")


### PR DESCRIPTION
This package provides a simple means of transforming comments into
images, headers, and text. Together with narrowed-page-navigation, it
provides a slide-show feature that still allows things like
compiler-supported editing of code examples.

The repository is at https://github.com/david-christiansen/live-code-talks.

I am the author of the package.