### PR TITLE
Fetch flycheck-clojure files from its own directory.

### DIFF
--- a/recipes/flycheck-clojure
+++ b/recipes/flycheck-clojure
@@ -1,1 +1,2 @@
-(flycheck-clojure :fetcher github :repo "clojure-emacs/squiggly-clojure" :branch "melpa")
+(flycheck-clojure :fetcher github :repo "clojure-emacs/squiggly-clojure"
+		  :files ("elisp/flycheck-clojure/*.el"))

--- a/recipes/flycheck-clojure
+++ b/recipes/flycheck-clojure
@@ -1,1 +1,1 @@
-(flycheck-clojure :fetcher github :repo "clojure-emacs/squiggly-clojure")
+(flycheck-clojure :fetcher github :repo "clojure-emacs/squiggly-clojure" :branch "melpa")


### PR DESCRIPTION
This repo will also hold a related mode (using the same clj library) for displaying inferred types, not using flycheck.