### PR TITLE
Adds recipe for seq.el

### DIFF
--- a/recipes/seq
+++ b/recipes/seq
@@ -1,0 +1,1 @@
+(seq :fetcher github :repo "NicolasPetton/seq.el")


### PR DESCRIPTION
This PR adds a recipe for seq.el.

seq.el will be included in the next release of Emacs, but having a package will hopefully help adoption of the library.