### PR TITLE
Add recipe for py-format-sql.el

### DIFF
--- a/recipes/py-format-sql
+++ b/recipes/py-format-sql
@@ -1,0 +1,3 @@
+(py-format-sql
+ :repo "paetzke/py-format-sql.el"
+ :fetcher github)


### PR DESCRIPTION
This PR adds a recipe for py-format-sql.el which provides commands to use the external format-sql tool to format SQL in the current buffer.
