### PR TITLE
clang-format moved to cfe repo

### DIFF
--- a/recipes/clang-format
+++ b/recipes/clang-format
@@ -1,3 +1,4 @@
 (clang-format
- :repo "kljohann/clang-format.el"
- :fetcher github)
+ :fetcher svn
+ :url "http://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format"
+ :files ("clang-format.el"))


### PR DESCRIPTION
My patch landed in [r225447](http://lists.cs.uiuc.edu/pipermail/cfe-commits/Week-of-Mon-20150105/120901.html) and the next improvement is [on its way](http://lists.cs.uiuc.edu/pipermail/cfe-commits/Week-of-Mon-20150112/121127.html).
This fixes #2202.