### PR TITLE
Add recipe for format-sql.el

### DIFF
--- a/recipes/format-sql
+++ b/recipes/format-sql
@@ -1,0 +1,3 @@
+(format-sql
+ :repo "paetzke/format-sql.el"
+ :fetcher github)


### PR DESCRIPTION
This PR adds a recipe for format-sql.el which provides commands to use the external format-sql tool to format SQL in the current buffer.