### PR TITLE
Add speed-type recipe

### DIFF
--- a/recipes/speed-type
+++ b/recipes/speed-type
@@ -1,0 +1,1 @@
+(speed-type :fetcher github :repo "hagleitn/speed-type")


### PR DESCRIPTION
Small package that let's you practice touch typing in emacs. I am the author. Repo is here: https://github.com/hagleitn/speed-type



