### PR TITLE
Add e2ansi

### DIFF
--- a/recipes/e2ansi
+++ b/recipes/e2ansi
@@ -1,0 +1,1 @@
+(e2ansi :repo "Lindydancer/e2ansi" :fetcher github)


### PR DESCRIPTION
The `e2ansi` package adds syntax highlighting support to `less`. It uses Emacs in batch mode and use ANSI sequences to renders buffer highlighted using font-lock. It adapts itself the the current theme settings, so the output will be similar to what you see in an interactive Emacs. It has support for terminals that can handle 8, 16, 256, or 24 bit colors.

Of course, `e2ansi` can be used interactively to generate ANSI:fied files, either manually or used as a component by other packages. This package is similar to ps-print (which generates postscript) and htmlize that generate HTML.

Sincerely,
    Anders Lindgren
