### PR TITLE
Add recipe for helm-pages

### DIFF
--- a/recipes/helm-pages
+++ b/recipes/helm-pages
@@ -1,0 +1,3 @@
+(helm-pages
+ :fetcher github
+ :repo "david-christiansen/helm-pages")


### PR DESCRIPTION
helm-pages lets you browse the pages (delimited by `page-delimiter`) in
the current buffer using Helm, in the style of `pages-directory`.

The repository is at https://github.com/david-christiansen/helm-pages

I am the author of the package.