### PR TITLE
new recipe for orgtb-join

### DIFF
--- a/recipes/orgtbl-join
+++ b/recipes/orgtbl-join
@@ -1,0 +1,3 @@
+(orgtbl-join
+ :fetcher github
+ :repo "tbanel/orgtbljoin")


### PR DESCRIPTION
I would like to submit the `orgtbl-join` package to Melpa.
- **What?** A master Org-mode table gets columns appended from a reference table.
  It is somewhat similar to the "outter join" feature of the _SQL language_.
- **Where?** Home page and full documentation here: https://github.com/tbanel/orgtbljoin
- **Who?** I am the author and maintainer.

If you accept it, this will be my third contribution to MELPA (after
`orgtbl-ascii-plot` and `orgtbl-aggregate`).

I would like to avoid the dependency on `"org"`, as I did for
`orgtbl-aggregate`. Often people have Org-mode already installed from
non-Melpa sources.

Regards
Thierry Banel
tbanelwebmin@free.fr