### PR TITLE
Add el-init recipe

### DIFF
--- a/recipes/el-init
+++ b/recipes/el-init
@@ -1,0 +1,1 @@
+(el-init :fetcher github :repo "HKey/el-init")


### PR DESCRIPTION
This is a loader inspired by init-loader.
It loads split configuration files with `require` instead of `load`.

Repository: https://github.com/HKey/el-init