### PR TITLE
Add recipe for aggressive-fill-paragraph package

### DIFF
--- a/recipes/aggressive-fill-paragraph
+++ b/recipes/aggressive-fill-paragraph
@@ -1,0 +1,2 @@
+(aggressive-fill-paragraph :fetcher github
+                           :repo "davidshepherd7/aggressive-fill-paragraph-mode")


### PR DESCRIPTION
An emacs minor-mode for keeping paragraphs filled in both comments and
prose.

Each time a space is inserted the current paragraph is refilled. Some
special behaviour is implemented in a few major modes where the default
fill-paragraph behaviour would affect code as well as comments.

The package repository is
[here](https://github.com/davidshepherd7/aggressive-fill-paragraph-mode).

I am the author of the package.