### PR TITLE
Remove dvorak-mode recipe.

### DIFF
--- a/recipes/dvorak-mode
+++ b/recipes/dvorak-mode
@@ -1,1 +1,0 @@
-(dvorak-mode :fetcher github :repo "proofit404/dvorak-mode")


### PR DESCRIPTION
This package was error prone, had many limitations and doesn't work on emacs 24.4.

Thats why I remove it.

Maybe in future I'll find normal way to implement it.