### PR TITLE
Add lisp-extra-font-lock

### DIFF
--- a/recipes/lisp-extra-font-lock
+++ b/recipes/lisp-extra-font-lock
@@ -1,0 +1,1 @@
+(lisp-extra-font-lock :repo "Lindydancer/lisp-extra-font-lock" :fetcher github)


### PR DESCRIPTION
This package highlight the location where local variables is created (bound, for example by `let') as well as quoted and backquoted constant expressions.
