### PR TITLE
Add recipe for visual-ascii-mode

### DIFF
--- a/recipes/visual-ascii-mode
+++ b/recipes/visual-ascii-mode
@@ -1,0 +1,1 @@
+(visual-ascii-mode :fetcher github :repo "Dewdrops/visual-ascii-mode")


### PR DESCRIPTION
[visual-ascii-mode](https://github.com/Dewdrops/visual-ascii-mode) is a minor mode to visualize ASCII code on buffer.