### PR TITLE
Add recipe for company-quickhelp

### DIFF
--- a/recipes/company-quickhelp
+++ b/recipes/company-quickhelp
@@ -1,0 +1,1 @@
+(company-quickhelp :fetcher github :repo "expez/company-quickhelp")


### PR DESCRIPTION
`company-quickhelp` adds popup documentation to `company-mode` when idling on a completion candidate.

Package builds and installs cleanly