### PR TITLE
e2ansi, included 'bin' directory.

### DIFF
--- a/recipes/e2ansi
+++ b/recipes/e2ansi
@@ -1,1 +1,1 @@
-(e2ansi :repo "Lindydancer/e2ansi" :fetcher github)
+(e2ansi :repo "Lindydancer/e2ansi" :fetcher github :files ("*.el" "bin"))


### PR DESCRIPTION
I just realised that a vital part of e2ansi was missing in the Melpa distribution. The `bin` directory contains the actual command line tools that generate ANSI output, `e2ansi-cat`, which is used by `less` to syntax highlight files.
