### PR TITLE
Added DTrace mode

### DIFF
--- a/recipes/dtrace-script-mode
+++ b/recipes/dtrace-script-mode
@@ -1,0 +1,1 @@
+(dtrace-script-mode :fetcher github :repo "dotemacs/dtrace-script-mode")


### PR DESCRIPTION
DTrace mode for editing D language.

Repo: https://github.com/dotemacs/dtrace-script-mode
To set your mind at ease: I'll maintain the mode from now on. This is not a fork.

Seeing how there was already a mode for a completely unrelated D
language, called d-mode.el, I worked with the original author on renaming this
mode and adding the license of his choice as there wasn't one present.