### PR TITLE
Adding tramp-hdfs.

### DIFF
--- a/recipes/tramp-hdfs
+++ b/recipes/tramp-hdfs
@@ -1,0 +1,1 @@
+(tramp-hdfs :fetcher github :repo "raghavgautam/tramp-hdfs")


### PR DESCRIPTION
tramp-hdfs allows access of hdfs(Hadoop Distributed File System) files and directories over tramp.

I am author of the package and its code can be found here: https://github.com/raghavgautam/tramp-hdfs.