### PR TITLE
Added kanji-mode recipe.

### DIFF
--- a/recipes/kanji-mode
+++ b/recipes/kanji-mode
@@ -1,1 +1,4 @@
-(kanji-mode :fetcher github :repo "wsgac/kanji-mode")
+(kanji-mode 
+ :fetcher github 
+ :repo "wsgac/kanji-mode"
+ :files ("kanji/*"))

--- a/recipes/kanji-mode
+++ b/recipes/kanji-mode
@@ -1,0 +1,1 @@
+(kanji-mode :fetcher github :repo "wsgac/kanji-mode")


### PR DESCRIPTION
This is a package for displaying stroke order of Japanese kanji characters at point in a text buffer. It uses SVG images named by the respective character's Unicode code and displays them with iimage-mode.

The repo is available here: https://github.com/wsgac/kanji-mode

I am the author of this package. You can contact me at wojciech.s.gac@gmail.com