### PR TITLE
Add a recipe for geeknote

### DIFF
--- a/recipes/geeknote
+++ b/recipes/geeknote
@@ -1,0 +1,1 @@
+(geeknote :repo "avendael/emacs-geeknote" :fetcher github)


### PR DESCRIPTION
Geeknote is a python command line utility that allows using Evernote through the terminal. This package wraps geeknote commands in elisp to allow its usage within Emacs. It expects geeknote to be installed in the user's system, as described in the original geeknote [documentation](http://www.geeknote.me/documentation/#creating-notes) and this package's [documentation](https://github.com/avendael/emacs-geeknote/blob/master/README.md).

I am the author of [this package](https://github.com/avendael/emacs-geeknote). The recipe has been tested to build and install on the sandbox.