### PR TITLE
remove magit-log-edit recipe

### DIFF
--- a/recipes/magit-log-edit
+++ b/recipes/magit-log-edit
@@ -1,1 +1,0 @@
-(magit-log-edit :fetcher github :repo "magit/magit-log-edit")


### PR DESCRIPTION
This package is obsolete and contained at least one longstanding bug in
a function that most users would run into eventually.  However that has
only been reported three times (without mentioning that `magit-log-edit`
was installed, that's why it didn't get fixed the first time).  This
suggests that it is not actually used by many people anymore, hurray.

This package originally was created because it's replacement,
`git-commit-mode`, had *different* issues than the library it replaced.
Some users considered these issues worse than the ones it fixed, which
I always strongly disagreed with.  But these users were quite outspoken
about their opinion and so I created this package to get them of my
back.

The issues in the successor have long been fixed.  However the successor
only receives the final polish on Magit's `next` branch, and so I
intended to delay the deprecation of `magit-log-edit` until the next
Magit release.  But because there's always a fresh supply of users who
shot themselves in the foot by installing this package, despite all the
warnings of it being obsolete, I am removing it now.  This will save
those users, who didn't make a informed decision to use it, as well as
myself further unnecessary work.

Users who still insist on degrading their commit behavior, from now on
have to do it by installing `magit-log-edit` manually.