### PR TITLE
Change rust-mode recipe after the Rust team moved it into its own repo

### DIFF
--- a/recipes/rust-mode
+++ b/recipes/rust-mode
@@ -1,3 +1,3 @@
-(rust-mode :repo "rust-lang/rust"
+(rust-mode :repo "rust-lang/rust-mode"
            :fetcher github
-           :files ("src/etc/emacs/rust-mode.el"))
+           :files ("rust-mode.el"))


### PR DESCRIPTION
The Rust team has moved rust-mode into its own repo rather than being embedded in the rust compiler source tree--see rust-lang/rust#21738.