### PR TITLE
Add browse-at-remote recipe

### DIFF
--- a/recipes/browse-at-remote
+++ b/recipes/browse-at-remote
@@ -1,0 +1,1 @@
+(browse-at-remote :repo "rmuslimov/browse-at-remote" :fetcher github)


### PR DESCRIPTION
This reincarnation of **openatgithub.el** recipe. I've renamed and now it has more precise package name. Provides function to browse code on github/bitbucket sites, supports dired-mode. 