### PR TITLE
A better smart-assignment for R (and S) with the =-key, no underscores.

### DIFF
--- a/recipes/ess-smart-equals
+++ b/recipes/ess-smart-equals
@@ -1,0 +1,1 @@
+(ess-smart-equals :fetcher github :repo "genovese/ess-smart-equals")


### PR DESCRIPTION
This provides an electric key-binding and a minor mode within ESS for 
R and S source and interaction that makes the =-key intelligently select 
the intended meaning based on the previous context.

The package repository is on github at [genovese/ess-smart-equals](https://github.com/genovese/ess-smart-equals). 
I am the original package author and maintainer.

This has been checked with flyspell-package and by building
in a clone of the MELPA repository with testing under a sandbox,
as described in the MELPA documentation.

Note that flycheck-package cannot determine that `ess-site` is the
proper feature to load for package `ess`. But there is no problem, and 
the package loads and runs correctly.