### PR TITLE
add linum-off

### DIFF
--- a/recipes/linum-off
+++ b/recipes/linum-off
@@ -1,0 +1,1 @@
+(linum-off :fetcher github :repo "emacsmirror/linum-off")


### PR DESCRIPTION
linum-off can let user set which mode he/she want to disable, so
user can add less code in their's .emacs.

This package originally introduce in emacswiki, but can't find author's
github/bitbucket, so use emacsmirror instead.

Signed-off-by: Yen-Chin Lee <coldnew.tw@gmail.com>