### PR TITLE
add eshell-autojump

### DIFF
--- a/recipes/eshell-autojump
+++ b/recipes/eshell-autojump
@@ -1,1 +1,1 @@
-(eshell-autojump :fetcher wiki)
+(eshell-autojump :fetcher github :repo "coldnew/eshell-autojump")

--- a/recipes/eshell-autojump
+++ b/recipes/eshell-autojump
@@ -1,0 +1,1 @@
+(eshell-autojump :fetcher wiki)


### PR DESCRIPTION
eshell-autojump is autojump command for eshell.

Signed-off-by: Yen-Chin Lee <coldnew.tw@gmail.com>