### PR TITLE
RECIPE: shell-split-string.el

### DIFF
--- a/recipes/shell-split-string
+++ b/recipes/shell-split-string
@@ -1,0 +1,1 @@
+(shell-split-string :repo "10sr/shell-split-string-el" :fetcher github)


### PR DESCRIPTION
A simple utility that splits strings using shell-like syntax.

The function `shell-split-string` works like:

```el
(shell-split-string "abc")  ->  '("abc")
(shell-split-string "abc  def")  ->  '("abc" "def")
(shell-split-string "abc \"def ghi\"")  ->  '("abc" "def ghi")
(shell-split-string "abc 'de f'ghi") -> '("abc" "de fghi")
(shell-split-string "abc \"d\\\"ef\"") -> '("abc" "d\"ef")
```

I'm the maintainer of `shell-split-string.el`.
URL: http://github.com/10sr/shell-split-string-el
