### PR TITLE
Fixed kanji-mode recipe to create a proper filesystem hierarchy

### DIFF
--- a/recipes/kanji-mode
+++ b/recipes/kanji-mode
@@ -1,4 +1,6 @@
 (kanji-mode 
  :fetcher github 
  :repo "wsgac/kanji-mode"
- :files ("kanji/*"))
+ :files ("*.el"
+	 ("kanji" "kanji/*"))
+ )


### PR DESCRIPTION
I noticed that my recipe for kanji-mode did not work properly, because it did not recreate the directory structure of the project.