### PR TITLE
Add ox-ioslide

### DIFF
--- a/recipes/ox-ioslide
+++ b/recipes/ox-ioslide
@@ -1,0 +1,2 @@
+(ox-ioslide :repo "coldnew/org-ioslide" :fetcher github
+            :old-names (org-ioslide) :branch "master")


### PR DESCRIPTION
ox-ioslide (org-ioslide) exports your org-mode file to Google 2013 I/O
presentations.

Signed-off-by: Yen-Chin Lee <coldnew.tw@gmail.com>