### PR TITLE
add purpose recipe

### DIFF
--- a/recipes/purpose
+++ b/recipes/purpose
@@ -1,0 +1,3 @@
+(purpose :repo "bmag/emacs-purpose"
+	 :fetcher github
+	 :files ("*.el"))


### PR DESCRIPTION
Purpose assigns purposes to buffers and windows automatically according to some configuration variables (configuration can be changed by the user).  Such purposes could be 'edit (for editing code/text), 'terminal (for shells and REPLs), etc.  Then, Purpose provides the user with alternative commands for find-file, switch-to-buffer, etc. that display buffers in windows that match their purposes.
The aim of this package is to help the user maintain a window layout that doesn't change too much, which is something I had trouble doing without this package, when working on large projects.

https://github.com/bmag/emacs-purpose

I'm the maintainer (and author) of this package.