### PR TITLE
add splitjoin

### DIFF
--- a/recipes/splitjoin
+++ b/recipes/splitjoin
@@ -1,0 +1,1 @@
+(splitjoin :fetcher github :repo "syohex/emacs-splitjoin")


### PR DESCRIPTION
`splitjoin` is Emacs port of [splitjoin.vim](https://github.com/AndrewRadev/splitjoin.vim).

https://github.com/syohex/emacs-splitjoin
(CC: https://github.com/syohex/emacs-splitjoin/issues/1)