### PR TITLE
Add package recipe for "org-pdfview"

### DIFF
--- a/recipes/org-pdfview
+++ b/recipes/org-pdfview
@@ -1,0 +1,1 @@
+(org-pdfview :repo "markus1189/org-pdfview" :fetcher github)


### PR DESCRIPTION
Hi,

the repos is here: 
https://github.com/markus1189/org-pdfview

I was not sure what version of pdf-tools to require, so I took the current one:
```elisp
;; Package-Requires: ((org "6.01") (pdf-tools "20150208.715"))
```

Is that sensible?

Cheers,
Markus