### PR TITLE
Add simplenote2.el

### DIFF
--- a/recipes/simplenote2
+++ b/recipes/simplenote2
@@ -1,0 +1,1 @@
+(simplenote2 :fetcher github :repo "alpha22jp/simplenote2.el")


### PR DESCRIPTION
**NOTE:** just a place holder for now. Once the original author gives the green light, I'll remove this notice and update this message. Please don't merge it just yet.

simplenote2.el surpases simplenote.el as it handles version 2 of the
Simplenote API.