### PR TITLE
Add the Idris logo to the idris-mode package recipe

### DIFF
--- a/recipes/idris-mode
+++ b/recipes/idris-mode
@@ -1,1 +1,4 @@
-(idris-mode :repo "idris-hackers/idris-mode" :fetcher github)
+(idris-mode
+ :repo "idris-hackers/idris-mode"
+ :fetcher github
+ :files (:defaults "logo-small.png"))


### PR DESCRIPTION
The logo is shown at REPL startup, so it needs to be in the package.