### PR TITLE
Includes missing lenticular.org file.

### DIFF
--- a/recipes/lentic
+++ b/recipes/lentic
@@ -1,1 +1,3 @@
-(lentic :fetcher github :repo "phillord/lentic" :old-names (linked-buffer))
+(lentic :fetcher github :repo "phillord/lentic"
+        :files (:defaults "lenticular.org")
+        :old-names (linked-buffer))


### PR DESCRIPTION
This file includes the documentation for lentic and is needed as part of
the package.