### PR TITLE
Add org2jekyll recipe

### DIFF
--- a/recipes/org2jekyll
+++ b/recipes/org2jekyll
@@ -1,0 +1,1 @@
+(org2jekyll :fetcher github :repo "ardumont/org2jekyll")


### PR DESCRIPTION
Hello,

> A brief summary of what the package does.

Permits to blog using org-mode and publishing to a jekyll install.

> A direct link to the package repository.

https://github.com/ardumont/org2jekyll.git

> Your association with the package (e.g., are you the maintainer? have you contributed? do you just like the package a lot?).

Maintainer.

> Test that the package builds properly via make recipes/<recipe>, or pressing C-c C-c in the recipe buffer.

```sh
# tony at dagobah in ~/repo/perso/melpa on git:add-org2jekyll o [20:20:21]
$ make recipes/org2jekyll
• Building recipe org2jekyll ...
/run/current-system/sw/bin/timeout -k 60 600 emacs --no-site-file --batch -l package-build.el --eval "(let ((package-build-stable nil) (package-build-write-melpa-badge-images t) (package-build-archive-dir (expand-file-name \"./packages\" pb/this-dir\"))) (package-build-archive 'org2jekyll))"

;;; org2jekyll

Fetcher: github
Source: ardumont/org2jekyll

Cloning git://github.com/ardumont/org2jekyll.git to /home/tony/repo/perso/melpa/working/org2jekyll/
/home/tony/repo/perso/melpa/working/org2jekyll/org2jekyll.el -> /tmp/org2jekyll15544cMk/org2jekyll-20150124.2128/org2jekyll.el
/home/tony/repo/perso/melpa/working/org2jekyll/org2jekyll-pkg.el -> /tmp/org2jekyll15544cMk/org2jekyll-20150124.2128/org2jekyll-pkg.el
Wrote /home/tony/repo/perso/melpa/packages/org2jekyll-readme.txt
File: /home/tony/repo/perso/melpa/packages/org2jekyll-20150124.2128.entry
Contacting host: img.shields.io:80
Wrote /home/tony/repo/perso/melpa/packages/org2jekyll-badge.svg
Built in 0.574s, finished at Mon Feb 16 20:21:00 2015
✓ Wrote 4.0K -rw-r--r-- 1 tony users 187 Feb 16 20:21 ./packages/org2jekyll-20150124.2128.entry
32K -rw-r--r-- 1 tony users 30K Feb 16 20:21 ./packages/org2jekyll-20150124.2128.tar
4.0K -rw------- 1 tony users 750 Feb 16 20:21 ./packages/org2jekyll-badge.svg
4.0K -rw-r--r-- 1 tony users 705 Feb 16 20:21 ./packages/org2jekyll-readme.txt
Sleeping for 0 ...
sleep 0


```
