### PR TITLE
add new recipe for haskell-highlight-indentation

### DIFF
--- a/recipes/haskell-highlight-indentation
+++ b/recipes/haskell-highlight-indentation
@@ -1,0 +1,3 @@
+(haskell-highlight-indentation
+ :repo "nilninull/haskell-highlight-indentation"
+ :fetcher github)


### PR DESCRIPTION
A highlight indentaion mode mainly intended to work with haskell language programming.
And I'm the author.

https://github.com/nilninull/haskell-highlight-indentation