### PR TITLE
Add recipe for railscasts-theme.el

### DIFF
--- a/recipes/railscasts-theme
+++ b/recipes/railscasts-theme
@@ -1,0 +1,1 @@
+(railscasts-theme :repo "mikenichols/railscasts-theme" :fetcher github)


### PR DESCRIPTION
This is a port of the classic railscasts color theme to the new `deftheme` style in emacs 24.

Package repository: https://github.com/mikenichols/railscasts-theme

I really like the railscasts color theme, and I've added my own tweaks over the years that I really believe make the theme better. I'd like to see this package get into melpa so others can use it.