### PR TITLE
Add id-manager

### DIFF
--- a/recipes/id-manager
+++ b/recipes/id-manager
@@ -1,0 +1,2 @@
+(id-manager :fetcher github
+	    :repo "kiwanami/emacs-id-manager")


### PR DESCRIPTION
Add emacs-id-manager of @kiwanami 

T his is a password manager that serves as an alternative to
1Password/Keepass/Lastpass. It hooks into helm for quick password lookup
and copies that password to the clipboard. A few seconds later it copies
the empty string, to clear the password.

It also has the ability to generate random new passwords and quickly add
new records.

The passwords are stored in an implicitly encrypted tab separated file,
so the passwords are safe and not dependent on any other program.

The package can be found here: https://github.com/kiwanami/emacs-id-manager

I've been using this package for a long time and contributed a small patch.