### PR TITLE
Add term-run recipe

### DIFF
--- a/recipes/term-run
+++ b/recipes/term-run
@@ -1,0 +1,1 @@
+(term-run :repo "10sr/term-run-el" :fetcher github)


### PR DESCRIPTION
`term-run.el` provides two functions to invoke programs with arguments
in a buffer which works as a terminal-emulator.


I'm the maintainer of `term-run.el`.
URL: http://github.com/10sr/term-run-el
