### PR TITLE
Exclude two test/build files.

### DIFF
--- a/recipes/lentic
+++ b/recipes/lentic
@@ -1,3 +1,5 @@
 (lentic :fetcher github :repo "phillord/lentic"
-        :files (:defaults "lenticular.org")
+        :files (:defaults
+                "lenticular.org"
+                (:exclude "build.el" "noisy-change.el"))
         :old-names (linked-buffer))


### PR DESCRIPTION
Neither of these files is essential to the functioning of lentic and
at least one of them causes byte compile errors.

Sorry for another PR. This has taken me rather longer to get right than it should have!