### PR TITLE
Add ein-mumamo

### DIFF
--- a/recipes/ein-mumamo
+++ b/recipes/ein-mumamo
@@ -1,2 +1,2 @@
 (ein-mumamo :repo "millejoh/ein-mumamo" :fetcher github
-            :files ("*"))
+            :files ("*.el"))

--- a/recipes/ein-mumamo
+++ b/recipes/ein-mumamo
@@ -1,0 +1,2 @@
+(ein-mumamo :repo "millejoh/ein-mumamo" :fetcher github
+            :files ("*"))


### PR DESCRIPTION
ein-mumamo factors out support for MuMaMo (nxhtml's Multiple Major Mode)
from emacs-ipython-notebook. It also includes all the nxhtml
dependencies in one place since nxhtml is currently not installable from
MELPA.