### PR TITLE
recipes: Add company-coq

### DIFF
--- a/recipes/company-coq
+++ b/recipes/company-coq
@@ -1,0 +1,4 @@
+(company-coq
+ :repo "cpitclaudel/company-coq"
+ :fetcher github
+ :files (:defaults "refman"))


### PR DESCRIPTION
company-coq is a company back-end that offers documentation and keywords
autocompletion when editing Coq proof scripts.

I've tested this as directed in the manual, and everything seems to work
great on Emacs 24.4. I had a bit more trouble when testing the package
on 24.3 in an Ubuntu VM; the dependencies were compiled in incorrect
order (for some reason company-math was compiled first, so the compilation of
company-math failed when it tried to require company; similarly,
company-coq failed when it tried to require company-math, as
company-math had already failed). Did I do anything wrong there?