### PR TITLE
Add phpcbf

### DIFF
--- a/recipes/phpcbf
+++ b/recipes/phpcbf
@@ -1,0 +1,3 @@
+(phpcbf
+ :repo "nishimaki10/emacs-phpcbf"
+ :fetcher github)


### PR DESCRIPTION
https://github.com/nishimaki10/emacs-phpcbf

Format PHP code in Emacs using [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)'s `phpcbf` command.