### PR TITLE
Added evil-annoying-arrows

### DIFF
--- a/recipes/evil-annoying-arrows
+++ b/recipes/evil-annoying-arrows
@@ -1,0 +1,3 @@
+(evil-annoying-arrows-mode
+ :repo "endrebak/evil-annoying-arrows"
+ :fetcher github)

--- a/recipes/evil-annoying-arrows
+++ b/recipes/evil-annoying-arrows
@@ -1,3 +1,3 @@
-(evil-annoying-arrows-mode
+(evil-annoying-arrows
  :repo "endrebak/evil-annoying-arrows"
  :fetcher github)


### PR DESCRIPTION
I created an evil-version of the annoying-arrows package (already in melpa) with the [blessing](https://github.com/magnars/annoying-arrows-mode.el/issues/5) of the [original author](https://github.com/magnars): 

```
I'm perfectly fine with a separate evil-annoying-arrows package,
or if you want to add a pull request that's good too. :)
```

I wanted to just update his package to work with evil (and truly tried), but evil is slightly quirky and it was a true pain in the ass. In the end I gave up on creating a version that worked for both vanilla and evil emacs.

All this package does for now is ring the bell if you use the arrow keys or hjkl too much. It also shows suggestions for more efficient commands to achieve the same movements.