### PR TITLE
add recipe for imenu-list

### DIFF
--- a/recipes/imenu-list
+++ b/recipes/imenu-list
@@ -1,0 +1,2 @@
+(imenu-list :repo "bmag/imenu-list"
+	    :fetcher github)


### PR DESCRIPTION
imenu-list shows the imenu entries of the current buffer in another buffer. It's a convenient way to see the current file's structure in a side window. imenu-list also keeps track of changes and automatically updates the imenu-list buffer. Since it uses imenu, it supports any language that has imenu support.

repository: https://github.com/bmag/imenu-list

I'm the author of imenu-list.