### PR TITLE
Adding recipe for broadcast mode

### DIFF
--- a/recipes/broadcast
+++ b/recipes/broadcast
@@ -1,0 +1,2 @@
+(broadcast :fetcher git
+       :url "https://github.com/killdash9/broadcast.el.git")

--- a/recipes/broadcast-mode
+++ b/recipes/broadcast-mode
@@ -1,2 +1,0 @@
-(broadcast-mode :fetcher git
-       :url "https://github.com/killdash9/broadcast-mode.el.git")

--- a/recipes/broadcast-mode
+++ b/recipes/broadcast-mode
@@ -1,0 +1,2 @@
+(broadcast-mode :fetcher git
+       :url "https://github.com/killdash9/broadcast-mode.el.git")


### PR DESCRIPTION
Broadcast mode is a minor mode for linking buffers together for simultaneous navigation and editing.  The project is hosted on github at https://github.com/killdash9/broadcast-mode.el
I am the original author of this package.  Please consider hosting it on the melpa repository.