### PR TITLE
Update jedi(auto-complete) and add company-jedi recipe

### DIFF
--- a/recipes/company-jedi
+++ b/recipes/company-jedi
@@ -1,0 +1,2 @@
+(company-jedi :fetcher github
+              :repo "syohex/emacs-company-jedi")

--- a/recipes/jedi
+++ b/recipes/jedi
@@ -1,3 +1,3 @@
 (jedi :fetcher github
       :repo "tkf/emacs-jedi"
-      :files ("jedi*" "Makefile" "setup.py"))
+      :files ("jedi.el"))

--- a/recipes/jedi-core
+++ b/recipes/jedi-core
@@ -1,0 +1,3 @@
+(jedi-core :fetcher github
+           :repo "tkf/emacs-jedi"
+           :files ("jedi-core.el" "jediepcserver.py" "Makefile" "setup.py"))


### PR DESCRIPTION
`emacs-jedi` supports both `auto-complete` and `company-mode`.
So I update jedi recipe and add `company-jedi` recipe.

See
 - https://github.com/tkf/emacs-jedi/pull/180
 - https://github.com/tkf/emacs-jedi/pull/202