### PR TITLE
Delete helm-projectile-all

### DIFF
--- a/recipes/helm-projectile-all
+++ b/recipes/helm-projectile-all
@@ -1,2 +1,0 @@
-(helm-projectile-all :repo "spatz/helm-projectile-all"
-                     :fetcher github)


### PR DESCRIPTION
I no longer maintain this package as the functionality was integrated into helm-projectile as `helm-projectile-find-file-in-known-projects`.