### PR TITLE
Add recipe for git-wip-timemachine.

### DIFF
--- a/recipes/git-wip-timemachine
+++ b/recipes/git-wip-timemachine
@@ -1,0 +1,3 @@
+(git-wip-timemachine
+ :fetcher github
+ :repo "itsjeyd/git-wip-timemachine")


### PR DESCRIPTION
`git-wip-timemachine` is a modified version of [`git-timemachine`](https://github.com/pidu/git-timemachine) by Peter Stiernström that allows you to browse [`git-wip`](https://github.com/itsjeyd/git-wip) versions of files from Emacs.

Repository: https://github.com/itsjeyd/git-wip-timemachine

I am the author of `git-wip-timemachine`.