### PR TITLE
Add weibo.emacs recipe

### DIFF
--- a/recipes/weibo
+++ b/recipes/weibo
@@ -1,0 +1,2 @@
+(weibo :repo "austin-----/weibo.emacs"
+       :fetcher github)


### PR DESCRIPTION
[austin-----/weibo.emacs](https://github.com/austin-----/weibo.emacs) is a Sina Weibo client for Emacs. @austin----- is the author of this package. I've confirmed this package builds properly by run `C-c C-c` in the recipe buffer.