### PR TITLE
Add a recipe for zombie-mode

### DIFF
--- a/recipes/zombie-mode
+++ b/recipes/zombie-mode
@@ -1,0 +1,1 @@
+(zombie-mode :fetcher github :repo "david-christiansen/zombie-mode")


### PR DESCRIPTION
This is a minor mode for interacting with Zombie, a dependently typed programming language. It's a minor mode because `haskell-mode` usually works well enough to get syntax highlighting. Right now, it just includes a customized compilation command.

The primary, repo is at https://github.com/david-christiansen/zombie-mode

I wrote the package.