### PR TITLE
Add recipe for zombie-trellys-mode

### DIFF
--- a/recipes/zombie-trellys-mode
+++ b/recipes/zombie-trellys-mode
@@ -1,0 +1,1 @@
+(zombie-trellys-mode :fetcher github :repo "david-christiansen/zombie-trellys-mode")


### PR DESCRIPTION
This supersedes #2562. Since that PR, it has been made into a major mode at the suggestion of @purcell and it has been renamed to `zombie-trellys-mode` to make it easier to find in the package list and less likely to conflict with other things called `zombie`.

This is a minor mode for interacting with Zombie, a dependently typed programming language. It's a derived mode based on haskell-mode because that highlighting is good enough much of the time and there hasn't yet been time to customize it further.

The primary repo is at https://github.com/david-christiansen/zombie-trellys-mode

I wrote the package.