### PR TITLE
Recipe for flycheck-local-flake8

### DIFF
--- a/recipes/flycheck-local-flake8
+++ b/recipes/flycheck-local-flake8
@@ -1,0 +1,1 @@
+(browse-at-remote :repo "rmuslimov/flycheck-local-flake8" :fetcher github)

--- a/recipes/flycheck-local-flake8
+++ b/recipes/flycheck-local-flake8
@@ -1,1 +1,1 @@
-(browse-at-remote :repo "rmuslimov/flycheck-local-flake8" :fetcher github)
+(flycheck-local-flake8 :repo "rmuslimov/flycheck-local-flake8" :fetcher github)


### PR DESCRIPTION
package flycheck-local-flake8 is plugin for flycheck. It provides more proper way to use flake8 checker, uses local setup.cfg  and virtualenv if available.