### PR TITLE
Change package named electric-spacing

### DIFF
--- a/recipes/electric-spacing
+++ b/recipes/electric-spacing
@@ -1,1 +1,3 @@
-(electric-spacing :fetcher github :repo "zk-phi/electric-spacing")
+(electric-spacing
+ :fetcher github
+ :repo "xwl/electric-spacing")


### PR DESCRIPTION
The current "electric-spacing" is a package started in 2014, while there
already was a much older and widely used package called "smart-operator"
which was renamed to "electric-spacing" in 2012.

The classic "electric-spacing" is in GNU ELPA and I think that MELPA
should revert to this package and the newer one should be renamed.