### PR TITLE
Add mynt-mode

### DIFF
--- a/recipes/mynt-mode
+++ b/recipes/mynt-mode
@@ -1,0 +1,3 @@
+(mynt-mode
+:fetcher github
+:repo "crshd/mynt-mode")


### PR DESCRIPTION
_A brief summary of what the package does._
This is a minor mode to make working with [mynt](http://mynt.uhnomoli.com) easier.
It adds a couple of commands and keybindings to eliminate switching between Emacs and terminals.

_A direct link to the package repository._
https://github.com/crshd/mynt-mode

_Your association with the package._
Maintainer

Builds and installs without problems.