### PR TITLE
Add recipe stickyfunc-enhance

### DIFF
--- a/recipes/stickyfunc-enhance
+++ b/recipes/stickyfunc-enhance
@@ -1,0 +1,1 @@
+(stickyfunc-enhance :fetcher github :repo "tuhdo/semantic-stickyfunc-enhance")


### PR DESCRIPTION
`stickyfunc-enhance` improves `semantic-stickyfunc-mode`: 

- Displays parameters scattered on multiple lines. Current `semantic-stickyfunc-mode` can only display parameter on the same line with the function name.
- Specifically handles Python. Values can be assigned to Python's parameters. Current `semantic-stickyfunc-mode` only displays parameter names but not its associated values. This package does.