### PR TITLE
Add recipe for helm-cscope

### DIFF
--- a/recipes/helm-cscope
+++ b/recipes/helm-cscope
@@ -1,0 +1,1 @@
+(helm-cscope :fetcher github :repo "alpha22jp/helm-cscope.el")


### PR DESCRIPTION
Dear @milkypostman 
I'd like to add `helm-cscope.el` which is helm interface for `xcscope.el`.