### PR TITLE
Adds missing documentation file for m-buffer.

### DIFF
--- a/recipes/m-buffer
+++ b/recipes/m-buffer
@@ -1,1 +1,3 @@
-(m-buffer :fetcher github :repo "phillord/m-buffer-el")
+(m-buffer :fetcher github :repo "phillord/m-buffer-el"
+          :files (:defaults
+                  "m-buffer-doc.org"))


### PR DESCRIPTION
m-buffer now uses lentic to generate its documentation
on the fly client side. This requires a top-level org
file which is used in the generation.

I haven't added this to the README of m-buffer yet, because I want to make sure that it is working before I do.
Please also see this PR for an explanation of which this file needs to be packaged.

https://github.com/milkypostman/melpa/pull/2511

Thanks!