### PR TITLE
Updated github username on noctilux-theme recipe.

### DIFF
--- a/recipes/noctilux-theme
+++ b/recipes/noctilux-theme
@@ -1,1 +1,1 @@
-(noctilux-theme :fetcher github :repo "stafu/noctilux-theme")
+(noctilux-theme :fetcher github :repo "sjrmanning/noctilux-theme")


### PR DESCRIPTION
Sorry, I know this is a bit annoying and pointless but as I've changed github username I figured it's probably best for this recipe to be updated. It's not currently broken as github automatically forwards repos on username changes, and I've held that username to make sure old repo links won't break, but just to be safe!

Cheers.