### PR TITLE
Add recipe for cider-eval-sexp-fu.el

### DIFF
--- a/recipes/cider-eval-sexp-fu.el
+++ b/recipes/cider-eval-sexp-fu.el
@@ -1,0 +1,1 @@
+(cider-eval-sexp-fu :repo "clojure-emacs/cider-eval-sexp-fu" :fetcher github)


### PR DESCRIPTION
Hi Steve,

This PR adds a recipe for [cider-eval-sexp-fu](https://github.com/syl20bnr/cider-eval-sexp-fu).

@bbatsov Are you ok to move this to clojure-emacs ?

Cheers,
syl20bnr