### PR TITLE
Add recipe for gscholar-bibtex.el

### DIFF
--- a/recipes/gscholar-bibtex
+++ b/recipes/gscholar-bibtex
@@ -1,0 +1,2 @@
+(gscholar-bibtex :repo "cute-jumper/gscholar-bibtex"
+                 :fetcher github)


### PR DESCRIPTION
gscholar-bibtex can retrieve BibTeX entry from Google Scholar. Users can input a query, select a search result from a buffer and decide which file the BibTeX entry to be written/appended to.

https://github.com/cute-jumper/gscholar-bibtex

I'm the maintainer of this package.