### PR TITLE
Add recipe for helm-rhythmbox

### DIFF
--- a/recipes/helm-rhythmbox
+++ b/recipes/helm-rhythmbox
@@ -1,0 +1,1 @@
+(helm-rhythmbox :fetcher github :repo "mrBliss/helm-rhythmbox")


### PR DESCRIPTION
The package depends on the built-in `dbus`, I'm not sure if it needs to be declared as a dependency.