### PR TITLE
Add jar-manifest-mode

### DIFF
--- a/recipes/jar-manifest-mode
+++ b/recipes/jar-manifest-mode
@@ -1,0 +1,1 @@
+(jar-manifest-mode :fetcher github :repo "omajid/jar-manifest-mode")


### PR DESCRIPTION
Add [jar-manifest-mode](https://github.com/omajid/jar-manifest-mode) that implements a major mode for editing [Manifest.mf files used in JARs](http://docs.oracle.com/javase/7/docs/technotes/guides/jar/jar.html#JAR_Manifest).