### PR TITLE
explicitly set branch for magit and related packages

### DIFF
--- a/recipes/git-commit-mode
+++ b/recipes/git-commit-mode
@@ -1,3 +1,4 @@
 (git-commit-mode :repo "magit/git-modes"
                  :fetcher github
+		 :branch "master"
                  :files ("git-commit-mode.el"))

--- a/recipes/git-rebase-mode
+++ b/recipes/git-rebase-mode
@@ -1,3 +1,4 @@
 (git-rebase-mode :repo "magit/git-modes"
                  :fetcher github
+		 :branch "master"
                  :files ("git-rebase-mode.el"))

--- a/recipes/magit
+++ b/recipes/magit
@@ -1,5 +1,6 @@
 (magit :fetcher github
        :repo "magit/magit"
+       :branch "master"
        :files ("magit.el"
 	       "magit-bisect.el"
 	       "magit-blame.el"

--- a/recipes/magit-annex
+++ b/recipes/magit-annex
@@ -1,2 +1,1 @@
-(magit-annex :fetcher github
-             :repo "magit/magit-annex")
+(magit-annex :fetcher github :repo "magit/magit-annex" :branch "master")

--- a/recipes/magit-stgit
+++ b/recipes/magit-stgit
@@ -1,1 +1,1 @@
-(magit-stgit :fetcher github :repo "magit/magit-stgit")
+(magit-stgit :fetcher github :repo "magit/magit-stgit" :branch "master")

--- a/recipes/magit-svn
+++ b/recipes/magit-svn
@@ -1,1 +1,1 @@
-(magit-svn :fetcher github :repo "magit/magit-svn")
+(magit-svn :fetcher github :repo "magit/magit-svn" :branch "master")

--- a/recipes/magit-topgit
+++ b/recipes/magit-topgit
@@ -1,1 +1,1 @@
-(magit-topgit :fetcher github :repo "magit/magit-topgit")
+(magit-topgit :fetcher github :repo "magit/magit-topgit" :branch "master")


### PR DESCRIPTION
I have just released 1.4.0 and am now preparing to release 2.1.0.  I am
now making the `next` branches of the various repositories the HEAD, but
would like the Melpa packages to be build from the `master` branches for
a little longer.  I will switch to the `next` branches approximately to
weeks before 2.1.0 is actually released.