### PR TITLE
Add recipe for ace-flyspell

### DIFF
--- a/recipes/ace-flyspell
+++ b/recipes/ace-flyspell
@@ -1,0 +1,2 @@
+(ace-flyspell :repo "cute-jumper/ace-flyspell"
+              :fetcher github)


### PR DESCRIPTION
Jump to and correct spelling errors using `ace-jump-mode` and flyspell. Once flyspell detects some spelling errors in the buffer, you can use `ace-flyspell-jump-word` to jump to some error or use `ace-flyspell-correct-word` to jump to and correct the misspelt word. See README under the GitHub project home for further details.

https://github.com/cute-jumper/ace-flyspell

I'm the maintainer of this package.
