### PR TITLE
add ember-mode recipe

### DIFF
--- a/recipes/ember-mode
+++ b/recipes/ember-mode
@@ -1,0 +1,2 @@
+(ember-mode
+ :fetcher github :repo "madnificent/ember-mode")


### PR DESCRIPTION
This adds a recipe for [ember-mode](https://github.com/madnificent/ember-mode) which provides a minor mode for Ember.js projects using ember-cli, with keybindings for fast navigation inside projects, running blueprint generators, and compilation-mode integration for building, serving, and testing. 

I've contributed code and I discussed this with the maintainer [here](https://github.com/madnificent/ember-mode/pull/5).