### PR TITLE
Add recipe for smart-region

### DIFF
--- a/recipes/smart-region
+++ b/recipes/smart-region
@@ -1,0 +1,1 @@
+(smart-region :repo "uk-ar/smart-region" :fetcher github)


### PR DESCRIPTION
Smart region guess what you want to select by one command.
If you call this command multiple times at the same position, it expands selected region (it calls ```er/expand-region```).
Else, if you move from the mark and call this command, it select the region rectangular (it call ```rectangle-mark-mode```).
Else, if you move from the mark and call this command at same column as mark, it add cursor to each line (it call ```mc/edit-lines```).
See README under the GitHub project home for further details.

https://github.com/uk-ar/smart-region

I'm the maintainer of this package.