### PR TITLE
Change dom to point to an updated, working version

### DIFF
--- a/recipes/dom
+++ b/recipes/dom
@@ -1,1 +1,1 @@
-(dom :fetcher wiki)
+(dom :fetcher github :repo "toroidal-code/dom.el")


### PR DESCRIPTION
I was trying to use the dom.el library recently, and found it didn't work on Emacs 23+, so I fixed the dependency issues and compile problems. This is just an updated version.