### PR TITLE
Add recipe for ace-pinyin

### DIFF
--- a/recipes/ace-pinyin
+++ b/recipes/ace-pinyin
@@ -1,0 +1,2 @@
+(ace-pinyin :repo "cute-jumper/ace-pinyin"
+            :fetcher github)


### PR DESCRIPTION
`ace-pinyin` is used to jump to Chinese character by pinyin with `ace-jump-mode`. The user inputs the first letter of the pinyin of the Chinese character, then jumps to the character using `ace-jump-char-mode`.

https://github.com/cute-jumper/ace-pinyin

I'm the maintainer of this package.
