### PR TITLE
remove magit-push-remote

### DIFF
--- a/recipes/magit-push-remote
+++ b/recipes/magit-push-remote
@@ -1,1 +1,0 @@
-(magit-push-remote :repo "tarsius/magit-push-remote" :fetcher github)


### PR DESCRIPTION
This package has been broken for a long time now.  It doesn't work as
intended with Magit v1.4.0 and with the next branch it is hopeless.

The feature tried to implement would be useful and will be implemented
as part of Magit itself after I have released v2.1.0.
See https://github.com/magit/magit/issues/1485.

But fixing magit-push-remote would effectively mean implementing that
from scratch, and since I do not have the time to do that before v2.1.0
is released I am instead deprecating this library.