### PR TITLE
Adjust circe to the new upstream repository layout.

### DIFF
--- a/recipes/circe
+++ b/recipes/circe
@@ -1,1 +1,1 @@
-(circe :repo "jorgenschaefer/circe" :fetcher github :files ("lisp/circe*.el"))
+(circe :repo "jorgenschaefer/circe" :fetcher github)

--- a/recipes/lcs
+++ b/recipes/lcs
@@ -1,1 +1,0 @@
-(lcs :repo "jorgenschaefer/circe" :fetcher github :files ("lisp/lcs.el"))

--- a/recipes/lui
+++ b/recipes/lui
@@ -1,1 +1,0 @@
-(lui :repo "jorgenschaefer/circe" :fetcher github :files ("lisp/lui*.el"))

--- a/recipes/shorten
+++ b/recipes/shorten
@@ -1,1 +1,0 @@
-(shorten :repo "jorgenschaefer/circe" :fetcher github :files ("lisp/shorten.el"))

--- a/recipes/tracking
+++ b/recipes/tracking
@@ -1,1 +1,1 @@
-(tracking :repo "jorgenschaefer/circe" :fetcher github :files ("lisp/tracking.el"))
+(tracking :repo "jorgenschaefer/circe" :fetcher github :files ("tracking.el" "shorten.el"))


### PR DESCRIPTION
Remove lui, lcs and shorten, as they are no longer separate packages, but simply included in circe. This should not pose a problem, as no other packages in MELPA depend on them.

As the tracking package is used by another package, leave the recipe, but adjust it to include the depended-on shorten.el.