### PR TITLE
Added recipe for wiki-summary

### DIFF
--- a/recipes/wiki-summary
+++ b/recipes/wiki-summary
@@ -1,0 +1,1 @@
+(wiki-summary :fetcher github :repo "jozefg/wiki-summary.el")


### PR DESCRIPTION
wiki-summary lets you view the summary portion of a Wikipedia article in Emacs with one function call.

Here's [a direct link](https://github.com/jozefg/wiki-summary.el) to the repo.