### PR TITLE
Add recipe for py-yapf.el

### DIFF
--- a/recipes/py-yapf
+++ b/recipes/py-yapf
@@ -1,0 +1,3 @@
+(py-yapf
+ :repo "paetzke/py-yapf.el"
+ :fetcher github)


### PR DESCRIPTION
This PR adds a recipe for py-yapf.el which provides commands to use the external yapf tool to format a Python buffer.