### PR TITLE
Use master branch in ido-ubiquitous

### DIFF
--- a/recipes/ido-ubiquitous
+++ b/recipes/ido-ubiquitous
@@ -1,2 +1,3 @@
-(ido-ubiquitous :repo "DarwinAwardWinner/ido-ubiquitous" :fetcher github)
-
+(ido-ubiquitous :repo "DarwinAwardWinner/ido-ubiquitous"
+                :fetcher github
+                :branch "master")


### PR DESCRIPTION
It has come to my attention that the ido-ubiquitous recipe tracks the bleeding-edge branch by default, which is a bad idea since I can and will (and recently did) break things on that branch. It should track the master branch instead.