### PR TITLE
 New recipes for ido-ubiquitous and ido-completing-read+

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,17 +267,17 @@ causes the default value shown above to be prepended to the specified file list.
 
 ### Example: Single File Repository
 
-[ido-ubiquitous](https://github.com/DarwinAwardWinner/ido-ubiquitous) is a repository that contains two files:
+[smex](https://github.com/nonsequitur/smex) is a repository that
+contains two files:
 
-* `README.md`
-* `ido-ubiquitous.el`
+* `README.markdown`
+* `smex.el`
 
-Since there is only one `.el` file, this package only needs the `:url` and `:fetcher` specified,
+Since there is only one `.el` file, this package only needs the `:url`
+and `:fetcher` specified,
 
 ```lisp
-(ido-ubiquitous
- :url "https://github.com/DarwinAwardWinner/ido-ubiquitous.git"
- :fetcher git)
+(smex :repo "nonsequitur/smex" :fetcher github)
 ```
 
 ### Example: Multiple Packages in one Repository

--- a/recipes/ido-completing-read+
+++ b/recipes/ido-completing-read+
@@ -1,0 +1,2 @@
+(ido-completing-read+ :repo "DarwinAwardWinner/ido-ubiquitous" :fetcher github
+                      :files ("ido-completing-read+.el"))

--- a/recipes/ido-ubiquitous
+++ b/recipes/ido-ubiquitous
@@ -1,2 +1,2 @@
-(ido-ubiquitous :repo "DarwinAwardWinner/ido-ubiquitous" :fetcher github)
-
+(ido-ubiquitous :repo "DarwinAwardWinner/ido-ubiquitous" :fetcher github
+                :files ("ido-ubiquitous.el"))


### PR DESCRIPTION
Part of ido-ubiquitous functionality has been spun out into a library
called ido-completing-read+. ido-ubiquitous has also been refactored.
Since they are both in the same git repo, now the recipes need to
specify specific files.