### PR TITLE
Add recipe for fcitx

### DIFF
--- a/recipes/fcitx
+++ b/recipes/fcitx
@@ -1,0 +1,2 @@
+(fcitx :repo "cute-jumper/fcitx.el"
+       :fetcher github)


### PR DESCRIPTION
This package aims to make [fcitx](https://github.com/fcitx/fcitx/) better in Emacs. This package provides a set of functions to disable fcitx temporarily, including defining prefix keys, evil support(kind of like https://github.com/vim-scripts/fcitx.vim, but not perfect yet), M-x, M-!, M-& and M-: support.

https://github.com/cute-jumper/fcitx-emacs

I'm the maintainer of this package.
