### PR TITLE
Merge ivy into swiper

### DIFF
--- a/recipes/ivy
+++ b/recipes/ivy
@@ -1,3 +1,0 @@
-(ivy :repo "abo-abo/swiper"
-     :fetcher github
-     :files ("ivy.el"))

--- a/recipes/swiper
+++ b/recipes/swiper
@@ -1,3 +1,3 @@
 (swiper :repo "abo-abo/swiper"
         :fetcher github
-        :files ("swiper.el"))
+        :files ("swiper.el" "ivy.el"))


### PR DESCRIPTION
This splitting didn't play well with the presence of these to packages in GNU ELPA as a single swiper package. So it's better to merge them here as well.
