### PR TITLE
Limiting codesearch recipe to codesearch.el.

### DIFF
--- a/recipes/codesearch
+++ b/recipes/codesearch
@@ -1,2 +1,3 @@
 (codesearch :fetcher github
-            :repo "abingham/codesearch.el")
+            :repo "abingham/codesearch.el"
+            :files ("codesearch.el"))


### PR DESCRIPTION
I've added a new file to the codesearch repository, and it'll get its own recipe. This keeps the files separate.