### PR TITLE
add theme-looper recipe

### DIFF
--- a/recipes/theme-looper
+++ b/recipes/theme-looper
@@ -1,0 +1,1 @@
+(theme-looper :repo "myTerminal/theme-looper" :fetcher github)


### PR DESCRIPTION
This package can be used to cycle through the available themes in Emacs 24 with a key-binding of your choice. Just a key combination to switch to the next theme.

The package repository can be found at [https://github.com/myTerminal/theme-looper](https://github.com/myTerminal/theme-looper).

I am the creator and maintainer of this package.