### PR TITLE
Add git-ps1-mode recipe

### DIFF
--- a/recipes/git-ps1-mode
+++ b/recipes/git-ps1-mode
@@ -1,0 +1,1 @@
+(git-ps1-mode :repo "10sr/git-ps1-mode-el" :fetcher github)


### PR DESCRIPTION
git-ps1-mode is a global minor-mode to print __git_ps1 in mode-line.

I'm the maintainer of this package.
https://github.com/10sr/git-ps1-mode-el