### PR TITLE
adding MATLAB and SRecode files to matlab-mode recipe

### DIFF
--- a/recipes/matlab-mode
+++ b/recipes/matlab-mode
@@ -1,4 +1,5 @@
 (matlab-mode
  :fetcher cvs
  :url ":pserver:anonymous@matlab-emacs.cvs.sourceforge.net:/cvsroot/matlab-emacs"
- :module "matlab-emacs")
+ :module "matlab-emacs"
+ :files ("*.el" "*.m" "toolbox/*.m" "templates/*.srt"))


### PR DESCRIPTION
Additionally fetch currently missing files for complete functionality of the matlab-mode recipe:

./dl_emacs_support.m
./toolbox/emacsdocomplete.m
./toolbox/emacsinit.m
./toolbox/opentoline.m
./templates/srecode-matlab.srt

Resolves #2601.