### PR TITLE
update stan-mode to account for refactoring of repo

### DIFF
--- a/recipes/stan-mode
+++ b/recipes/stan-mode
@@ -1,4 +1,4 @@
 (stan-mode
  :fetcher github
  :repo "stan-dev/stan-mode"
- :files ("stan-mode.el" "stan-keywords-lists.el" "ac-dict"))
+ :files ("stan-mode/*.el"))


### PR DESCRIPTION
stan-mode now in its own folder of the stan-dev/stan-mode repo
in order to separate it from the other packages, such stan-snippets.