### PR TITLE
Add new nodejs debugger: trepanjs

### DIFF
--- a/recipes/realgud
+++ b/recipes/realgud
@@ -19,6 +19,7 @@
             ("realgud/debugger/trepan2"   "realgud/debugger/trepan2/*.el")
             ("realgud/debugger/trepan3k"  "realgud/debugger/trepan3k/*.el")
             ("realgud/debugger/trepan8"   "realgud/debugger/trepan8/*.el")
+            ("realgud/debugger/trepanjs"  "realgud/debugger/trepanjs/*.el")
             ("realgud/debugger/trepanx"   "realgud/debugger/trepanx/*.el")
             ("realgud/debugger/zshdb"     "realgud/debugger/zshdb/*.el")
             ("realgud/lang" "realgud/lang/*.el")))


### PR DESCRIPTION
A little back story. Feel free to ignore this verbiage. 

In https://github.com/rocky/emacs-dbgr/issues/41 it was observed that full path information from v8 and 'node debug' for system libraries was missing. This of curse makes it hard for Emacs to track the files.
The suggestion was to work around this in the emacs interface. 

Having other troubles with "node debug", I've gone down the path of forking that code and making it look more like gdb. Hence this new debugger.