### PR TITLE
Fetching sql-indent from GitHub

### DIFF
--- a/recipes/sql-indent
+++ b/recipes/sql-indent
@@ -1,1 +1,1 @@
-(sql-indent :fetcher wiki)
+(sql-indent :fetcher github :repo "bsvingen/sql-indent")


### PR DESCRIPTION
The official location for sql-indent has been moved from [Emacswiki](http://www.emacswiki.org/emacs?SqlIndent) to [bsvingen/sql-indent](https://github.com/bsvingen/sql-indent) (in agreement with the previous maintainer), in order to get proper version control.

Changing package recipe to fetch from the GitHub repo.
