### PR TITLE
add recipe for repeatable-motion

### DIFF
--- a/recipes/repeatable-motion
+++ b/recipes/repeatable-motion
@@ -1,0 +1,3 @@
+(repeatable-motion
+  :repo "willghatch/emacs-repeatable-motion"
+  :fetcher github)


### PR DESCRIPTION
I made a package called repeatable-motion.  It's for wrapping motion commands to make them repeatable with commands called `repeat-motion-forward` and `repeat-motion-backward`.  So naturally I want to put it on Melpa!