### PR TITLE
Add recipe for bing-dict.el

### DIFF
--- a/recipes/bing-dict
+++ b/recipes/bing-dict
@@ -1,0 +1,2 @@
+(bing-dict :repo "cute-jumper/bing-dict.el"
+           :fetcher github)


### PR DESCRIPTION
bing-dict.el is a **minimalists'** Emacs extension to search (http://www.bing.com/dict). 
Support English to Chinese and Chinese to English.

https://github.com/cute-jumper/bing-dict.el

I'm the maintainer of this package.