### PR TITLE
Add recipe for space-trail package

### DIFF
--- a/recipes/space-trail
+++ b/recipes/space-trail
@@ -1,0 +1,3 @@
+(space-trail
+ :fetcher github
+ :repo "NateEag/emacs-space-trail")


### PR DESCRIPTION
[space-trail](https://github.com/NateEag/emacs-space-trail) is a package I put together for removing trailing whitespace in buffers when reasonable.

`delete-trailing-whitespace` is a built-in solution, but putting it in `before-save-hook` bit me a few times - trailing whitespace is actually meaningful in some file types (diffs and Markdown code blocks are the two I've run into, diffs being the more painful of the two).

space-trail does the right thing with the file types I know about, and offers extension points for the ones I don't.