### PR TITLE
`owp-theme-emacslove' have been merged to emacs-china repo

### DIFF
--- a/recipes/owp-theme-emacslove
+++ b/recipes/owp-theme-emacslove
@@ -1,3 +1,0 @@
-(owp-theme-emacslove :repo "emacs-china/owp-theme-emacslove"
-                     :fetcher github
-                     :files (:defaults "themes"))


### PR DESCRIPTION
The author of emacslove have merged emacslove to emacs-china repo, this package is not needed.