### PR TITLE
Add a recipe for xterm-keybinder

### DIFF
--- a/recipes/xterm-keybinder
+++ b/recipes/xterm-keybinder
@@ -1,0 +1,1 @@
+(xterm-keybinder :repo "yuutayamada/xterm-keybinder-el" :fetcher github :files ("*.el" "xterm-option"))


### PR DESCRIPTION
Hello, I added an Emacs extension to use C-M prefixed keybidings on xterm.