### PR TITLE
Add Recipe for sentence-navigation.el

### DIFF
--- a/recipes/sentence-navigation
+++ b/recipes/sentence-navigation
@@ -1,0 +1,3 @@
+(sentence-navigation
+  :fetcher github
+  :repo "angelic-sedition/emacs-sentence-navigation")


### PR DESCRIPTION
[sentence-navigation.el](https://github.com/angelic-sedition/emacs-sentence-navigation) provides sentence navigation commands (like the default forward-sentence) that are abbreviation aware (abbreviations won't end a sentence) as well as sentence text objects that can be used with evil. 