### PR TITLE
Add org-password-manager

### DIFF
--- a/recipes/org-password-manager
+++ b/recipes/org-password-manager
@@ -1,0 +1,3 @@
+(org-password-manager
+ :fetcher github
+ :repo "leafac/org-password-manager")


### PR DESCRIPTION
org-password-manager is a minimal password manager for Emacs Org mode.

Package author here.

Reference: https://github.com/leafac/org-password-manager