### PR TITLE
Add py-smart-operator recipe

### DIFF
--- a/recipes/py-smart-operator
+++ b/recipes/py-smart-operator
@@ -1,0 +1,1 @@
+(py-smart-operator :repo "rmuslimov/py-smart-operator" :fetcher github)


### PR DESCRIPTION
This is special implementation of smart-operator mode for python, as far as old smart-operator doesn't work fine and doesn't follow PEP recomendations