### PR TITLE
Add recipe for emms-player-mpv-jp-radios

### DIFF
--- a/recipes/emms-player-mpv-jp-radios
+++ b/recipes/emms-player-mpv-jp-radios
@@ -1,0 +1,7 @@
+(emms-player-mpv-jp-radios :fetcher github :repo "momomo5717/emms-player-mpv-jp-radios"
+                           :files ("*.el"
+                                   "agqr"
+                                   "hibiki"
+                                   "onsen"
+                                   "radiko"
+                                   "radiru"))


### PR DESCRIPTION
[emms-player-mpv-jp-radios](https://github.com/momomo5717/emms-player-mpv-jp-radios)

This provides emms players of mpv and stream lists for Japanese free streaming radio stations.

Thank you very much for your help.