### PR TITLE
retaining matlab-mode directory structure (#2700)

### DIFF
--- a/recipes/matlab-mode
+++ b/recipes/matlab-mode
@@ -2,4 +2,4 @@
  :fetcher cvs
  :url ":pserver:anonymous@matlab-emacs.cvs.sourceforge.net:/cvsroot/matlab-emacs"
  :module "matlab-emacs"
- :files ("*.el" "*.m" "toolbox/*.m" "templates/*.srt"))
+ :files ("*.el" "*.m" ("toolbox" "toolbox/*.m") ("templates" "templates/*.srt")))


### PR DESCRIPTION
Retaining `toolbox/` and `templates/` directory during installation of `matlab-mode`; (re-)fixes #2601, see also original pull request #2700