### PR TITLE
Add kibit helper

### DIFF
--- a/recipes/kibit-helper
+++ b/recipes/kibit-helper
@@ -1,3 +1,2 @@
 (kibit-helper :fetcher github
-              :repo "brunchboy/kibit-helper"
-              :files ("*.el"))
+              :repo "brunchboy/kibit-helper")

--- a/recipes/kibit-helper
+++ b/recipes/kibit-helper
@@ -1,0 +1,3 @@
+(kibit-helper :fetcher github
+              :repo "brunchboy/kibit-helper"
+              :files ("*.el"))


### PR DESCRIPTION
Provides convenient access to the [Kibit](https://github.com/jonase/kibit.git) Leiningen plugin for improving non-idiomatic Clojure code from within Emacs. Offers invocation of Kibit on the current project or a single buffer, and allows most suggestions to be automatically applied to the source files (upon request by the user).

I am the maintainer of the [kibit-helper](https://github.com/brunchboy/kibit-helper.git) package. I developed it in coordination with the maintainers of Kibit itself; they would like to be able to point at this package on melpa (assuming this pull request is approved), rather than including a bunch of Emacs Lisp in their own Readme, especially since I have added some significant new functionality beyond what is there today.

Thanks for considering this!