### PR TITLE
Add changelog as resource in clj-refactor

### DIFF
--- a/recipes/clj-refactor
+++ b/recipes/clj-refactor
@@ -1,1 +1,2 @@
-(clj-refactor :fetcher github :repo "magnars/clj-refactor.el")
+(clj-refactor :fetcher github :repo "magnars/clj-refactor.el"
+              :files (:defaults "CHANGELOG.md"))


### PR DESCRIPTION
In the spririt of being self-documenting we'd like to provide an
interactive command displaying recent changes to the package.

Hopefully this remedies the anti-pattern of updating a package and
browsing to github to find out what actually changed.