### PR TITLE
Add project-persist-drawer-adaptor-sr-speedbar

### DIFF
--- a/recipes/project-persist-drawer-adaptor-sr-speedbar
+++ b/recipes/project-persist-drawer-adaptor-sr-speedbar
@@ -1,0 +1,3 @@
+(project-persist-drawer-adaptor-sr-speedbar :fetcher github
+                                            :repo "rdallasgray/project-persist-drawer-adaptor-sr-speedbar"
+                                            :files ("lib/*"))


### PR DESCRIPTION
An adaptor to use [sr-speedbar](https://github.com/emacsmirror/sr-speedbar) with [project-persist-drawer](https://github.com/rdallasgray/project-persist-drawer).