### PR TITLE
Added recipe for autumn-light color theme

### DIFF
--- a/recipes/autumn-light-theme
+++ b/recipes/autumn-light-theme
@@ -1,3 +1,3 @@
-(color-theme-autumn-light
+(autumn-light-theme
  :fetcher github
  :repo "aalpern/emacs-color-theme-autumn-light")

--- a/recipes/color-theme-autumn-light
+++ b/recipes/color-theme-autumn-light
@@ -1,0 +1,3 @@
+(color-theme-autumn-light
+ :fetcher github
+ :repo "aalpern/emacs-color-theme-autumn-light")


### PR DESCRIPTION
Another color theme, which I've been using as my primary color theme since...back when Emacs 19 was the new hotness.  Passes basic `flywheel-package-setup` and MELPA build checks. 

https://github.com/aalpern/emacs-color-theme-autumn-light

![](https://raw.githubusercontent.com/aalpern/emacs-color-theme-autumn-light/master/autumn-light-theme.png)