### PR TITLE
Added recipe for green phosphor color theme

### DIFF
--- a/recipes/color-theme-green-phosphor
+++ b/recipes/color-theme-green-phosphor
@@ -1,0 +1,3 @@
+(color-theme-green-phosphor
+ :fetcher github
+ :repo "aalpern/emacs-color-theme-green-phosphor")

--- a/recipes/green-phosphor-theme
+++ b/recipes/green-phosphor-theme
@@ -1,3 +1,3 @@
-(color-theme-green-phosphor
+(green-phosphor-theme
  :fetcher github
  :repo "aalpern/emacs-color-theme-green-phosphor")


### PR DESCRIPTION
A retro color theme that harkens back to the days of old-school monochrome monitors. If I still had any of my grade-school Apple ][e code, I would totally hack on it with this theme. 

https://github.com/aalpern/emacs-color-theme-green-phosphor

![](https://github.com/aalpern/emacs-color-theme-green-phosphor/raw/master/green-phosphor-theme.png)