### PR TITLE
Rename project-persist-drawer-adaptor-sr-speedbar to ppd-sr-speedbar

### DIFF
--- a/recipes/ppd-sr-speedbar
+++ b/recipes/ppd-sr-speedbar
@@ -1,0 +1,3 @@
+(ppd-sr-speedbar :fetcher github
+                 :repo "rdallasgray/ppd-sr-speedbar"
+                 :files ("lib/*"))

--- a/recipes/project-persist-drawer-adaptor-sr-speedbar
+++ b/recipes/project-persist-drawer-adaptor-sr-speedbar
@@ -1,3 +1,0 @@
-(project-persist-drawer-adaptor-sr-speedbar :fetcher github
-                                            :repo "rdallasgray/project-persist-drawer-adaptor-sr-speedbar"
-                                            :files ("lib/*"))


### PR DESCRIPTION
As discussed in https://github.com/milkypostman/melpa/pull/2756