### PR TITLE
Remove company-ess. The functionality has been included into ESS itself

### DIFF
--- a/recipes/company-ess
+++ b/recipes/company-ess
@@ -1,4 +1,0 @@
-(company-ess
- :fetcher github
- :repo "Lompik/company-ess")
- 


### PR DESCRIPTION
This package provide completion for `company` for the ESS package. ESS is now providing built-in support for company (https://github.com/emacs-ess/ESS/commit/03ed3a0d829f1b96b67efc5291e78181e05de93f) on March 1st . Users should upgrade to the latest ESS. 