### PR TITLE
Add osx-trash

### DIFF
--- a/recipes/flycheck-haskell
+++ b/recipes/flycheck-haskell
@@ -1,2 +1,2 @@
 (flycheck-haskell :fetcher github :repo "flycheck/flycheck-haskell"
-                  :files ("*.el" "*.hs"))
+                  :files (:defaults "*.hs"))

--- a/recipes/osx-trash
+++ b/recipes/osx-trash
@@ -1,0 +1,2 @@
+(osx-trash :fetcher github :repo "lunaryorn/osx-trash.el"
+           :files (:defaults "*.scpt"))


### PR DESCRIPTION
osx-trash from https://github.com/lunaryorn/osx-trash.el provides support for the native trash can on OS X.