### PR TITLE
added recipe for xah-elisp-mode

### DIFF
--- a/recipes/xah-elisp-mode
+++ b/recipes/xah-elisp-mode
@@ -1,0 +1,1 @@
+(xah-elisp-mode :repo "xahlee/xah-elisp-mode" :fetcher github)


### PR DESCRIPTION
An alternative major mode for emacs lisp.

repo at https://github.com/xahlee/xah-elisp-mode

Am original author.

Comment, suggestions, welcome. Will fix things. Thanks a lot, again.