### PR TITLE
Add recipe for helm-gitignore

### DIFF
--- a/recipes/helm-gitignore
+++ b/recipes/helm-gitignore
@@ -1,0 +1,1 @@
+(helm-gitignore :fetcher github :repo "jupl/helm-gitignore")


### PR DESCRIPTION
[`helm-gitignore`](https://github.com/jupl/helm-gitignore) provides a configured helm to generate `.gitignore` files using [gitignore.io](https://www.gitignore.io/).