### PR TITLE
Switch to br0ns repo instead of dengste repo.

### DIFF
--- a/recipes/minimap
+++ b/recipes/minimap
@@ -1,1 +1,1 @@
-(minimap :fetcher github :repo "dustinlacewell/emacs-minimap")
+(minimap :fetcher github :repo "br0ns/emacs-minimap")


### PR DESCRIPTION
There have been no commits to dengste in more than year, while br0ns has
fixed more than half a dozen issues.