### PR TITLE
Revert "Delete package-safe-delete"

### DIFF
--- a/recipes/package-safe-delete
+++ b/recipes/package-safe-delete
@@ -1,0 +1,1 @@
+(package-safe-delete :fetcher github :repo "Fanael/package-safe-delete")


### PR DESCRIPTION
This reverts commit 762376f35ba12a9172128398fb857c295e35c82f.

Dependency-aware package removal in Emacs trunk doesn't supersede this package, for it will happily allow the user to delete dependencies, as long as they were installed manually.

Also, this package works in Emacs 24.1+, whereas the Emacs trunk functionality requires, obviously, Emacs trunk.