### PR TITLE
Rename docker recipe to docker-tramp

### DIFF
--- a/recipes/docker
+++ b/recipes/docker
@@ -1,1 +1,0 @@
-(docker :fetcher github :repo "emacs-pe/docker.el")

--- a/recipes/docker-tramp
+++ b/recipes/docker-tramp
@@ -1,0 +1,1 @@
+(docker-tramp :fetcher github :repo "emacs-pe/docker-tramp.el" :old-names (docker))


### PR DESCRIPTION
Alright, we came to agreement in emacs-pe/docker-tramp.el#1.

This is the first step of #2782

You can merge this.