### PR TITLE
Add avy-zap

### DIFF
--- a/recipes/avy-zap
+++ b/recipes/avy-zap
@@ -1,0 +1,2 @@
+(avy-zap :repo "cute-jumper/avy-zap"
+         :fetcher github)


### PR DESCRIPTION
Zap to char using `avy'. 

This package is basically a fork of the functionality of [ace-jump-zap](https://github.com/waymondo/ace-jump-zap), but using [avy](https://github.com/abo-abo/avy) instead of [ace-jump-mode](https://github.com/winterTTr/ace-jump-mode) as the jumping method.

https://github.com/cute-jumper/avy-zap

I'm the maintainer of this package.