### PR TITLE
Add recipe for emoji-cheat-sheet-plus

### DIFF
--- a/recipes/emoji-cheat-sheet-plus
+++ b/recipes/emoji-cheat-sheet-plus
@@ -1,0 +1,3 @@
+(emoji-cheat-sheet-plus :repo "syl20bnr/emacs-emoji-cheat-sheet-plus"
+                        :fetcher github
+                        :files (:defaults "emoji-cheat-sheet"))


### PR DESCRIPTION
Hi Steve,

This PR adds a recipe for [emoji-cheat-sheet-plus](https://github.com/syl20bnr/emacs-emoji-cheat-sheet-plus).
This is a fork from [emoji-cheat-sheet](https://github.com/ShingoFukuyama/emacs-emoji-cheat-sheet) which is not distributed in MELPA.
I hope @ShingoFukuyama will agree with this PR.

Cheers,
syl20bnr