### PR TITLE
New recipe: faff-theme

### DIFF
--- a/recipes/faff-theme
+++ b/recipes/faff-theme
@@ -1,0 +1,1 @@
+(faff-theme :repo "WJCFerguson/emacs-faff-theme" :fetcher github)


### PR DESCRIPTION
This is 'faff' theme - a light theme evolved from the default emacs theme.

I am the maintainer of faff-theme, here: https://github.com/WJCFerguson/emacs-faff-theme

I think I've followed the procedures, test installed etc., but this is my first melpa submission.
