### PR TITLE
Add recipe for indent-of-doom

### DIFF
--- a/recipes/indent-of-doom
+++ b/recipes/indent-of-doom
@@ -1,1 +1,0 @@
-(indent-of-doom :repo "attichacker/indent-of-doom" :fetcher github)

--- a/recipes/indent-of-doom
+++ b/recipes/indent-of-doom
@@ -1,0 +1,1 @@
+(indent-of-doom :repo "attichacker/indent-of-doom" :fetcher github)

--- a/recipes/indy
+++ b/recipes/indy
@@ -1,0 +1,1 @@
+(indy :repo "attichacker/indy" :fetcher github)


### PR DESCRIPTION
Hello,

Indent of doom is a small libary which provides a new TAB functionality and an EDSL to customize your indentation rules for a specific major mode. This let's you add rules e.g. indent 1 tab if the previous line ends on "[", "{" or "(".

https://github.com/AtticHacker/indent-of-doom

If I need to change anything please let me know, thanks!