### PR TITLE
Add common-lisp-snippets

### DIFF
--- a/recipes/common-lisp-snippets
+++ b/recipes/common-lisp-snippets
@@ -1,0 +1,4 @@
+(common-lisp-snippets
+ :repo "mrkkrp/common-lisp-snippets"
+ :fetcher github
+ :files ("*.el" "snippets"))


### PR DESCRIPTION
Hi, I checked out some collections of snippets (Yasnippet) in MELPA: you have good stuff for Clojure, Java, etc. What about Common Lisp? I've decided to share my personal collection of Common Lisp snippets, here:

https://github.com/mrkkrp/common-lisp-snippets

I think there should be some Common Lispers around who could make good use of it ;-)
