### PR TITLE
Add helm-commandlinefu recipe

### DIFF
--- a/recipes/helm-commandlinefu
+++ b/recipes/helm-commandlinefu
@@ -1,0 +1,1 @@
+(helm-commandlinefu :repo "xuchunyang/helm-commandlinefu" :fetcher github)


### PR DESCRIPTION
[helm-commandlinefu](https://github.com/xuchunyang/helm-commandlinefu) is a Helm extension to search and browse http://www.commandlinefu.com/.