### PR TITLE
Added emallson/narrow-reindent.el

### DIFF
--- a/recipes/narrow-reindent
+++ b/recipes/narrow-reindent
@@ -1,0 +1,2 @@
+(narrow-reindent :fetcher github
+                 :repo "emallson/narrow-reindent.el")


### PR DESCRIPTION
Adds a recipe for [narrow-reindent.el](https://github.com/emallson/narrow-reindent.el).

The purpose of the package is to align the contents of a narrowed region to the left margin of a window. This is especially useful in editing asynchronous JavaScript code (especially the kind that has fallen into callback hell), among other tasks.

I am the maintainer of the original package.