### PR TITLE
add recipe for standoff-mode

### DIFF
--- a/recipes/standoff-mode
+++ b/recipes/standoff-mode
@@ -1,0 +1,1 @@
+(standoff-mode :fetcher github :repo "lueck/standoff-mode")


### PR DESCRIPTION
A major mode for creating stand-off markup, also called external markup. It is written for use in the field of digital humanities and the manual annotation of training data for named-entity recognition.

https://github.com/lueck/standoff-mode.git

I'm the author of the package.