### PR TITLE
Add recipe for JonPRL mode

### DIFF
--- a/recipes/jonprl-mode
+++ b/recipes/jonprl-mode
@@ -1,0 +1,1 @@
+(jonprl-mode :fetcher github :repo "david-christiansen/jonprl-mode")


### PR DESCRIPTION
This adds a recipe for `jonprl-mode`, a major mode for the [JonPRL proof assistant](https://github.com/jonsterling/JonPRL).

I am the author of the major mode. The original repository is at https://github.com/david-christiansen/jonprl-mode .