### PR TITLE
Add recipe for boogie-friends

### DIFF
--- a/recipes/boogie-friends
+++ b/recipes/boogie-friends
@@ -1,0 +1,4 @@
+(boogie-friends
+ :fetcher github
+ :repo "boogie-org/boogie-friends"
+ :files ("emacs/*.el" "emacs/etc"))


### PR DESCRIPTION
Hi Steve,

This PR adds boogie-friends, a collection of Emacs modes for writing verified programs in languages of the Boogie family. Support is currently implemented for Dafny and Boogie. 

I grouped these modes together because there are pretty strong interdependencies at the moment; if more languages join this family then it might make sense then to split this package into multiple smaller ones. The dependency base is also a bit large (yasnippet + company), but both are required in order to provide good snippet completion. I'm trying to achieve an IDE-like experience out-of-the-box, so I'm not too sure about making these optional dependencies and letting users figure them out by themselves.

Cheers,
Clément.