### PR TITLE
Add shrink-whitespace, DWIM whitespace removal

### DIFF
--- a/recipes/shrink-whitespace
+++ b/recipes/shrink-whitespace
@@ -1,0 +1,1 @@
+(shrink-whitespace :repo "jcpetkovich/shrink-whitespace.el" :fetcher github)


### PR DESCRIPTION
`shrink-whitespace` is a smart clone of a sort of combination between
`just-one-space` and `delete-horizontal-space` into a convenient DWIM
function. It "shrinks" whitespace around point in a simplistic spammable
and logical way.

Here is the repo: https://github.com/jcpetkovich/shrink-whitespace.el

I am the repo/package maintainer.