### PR TITLE
Add easy-escape

### DIFF
--- a/recipes/easy-escape
+++ b/recipes/easy-escape
@@ -1,0 +1,3 @@
+(easy-escape
+ :repo "cpitclaudel/easy-escape"
+ :fetcher github)


### PR DESCRIPTION
Hi Steve,

This is a simple mode that I put together because I was annoying of counting backslashes in regular expressions. `easy-escape-minor-mode` composes double backslashes (escape characters) into single backslashes, and highlights them to improve readability. The underlying buffer text is not modified.

Here's a picture:

![screenshot](https://raw.githubusercontent.com/cpitclaudel/easy-escape/master/img/easy-escape.png)

Cheers,
Clément.