### PR TITLE
add recipe for typescript-mode

### DIFF
--- a/recipes/typescript-mode
+++ b/recipes/typescript-mode
@@ -1,0 +1,1 @@
+(typescript-mode :fetcher github :repo "ananthakumaran/typescript.el")


### PR DESCRIPTION
This is a stripped down version of typescript mode released by microsoft [source](http://blogs.msdn.com/b/interoperability/archive/2012/10/01/sublime-text-vi-emacs-typescript-enabled.aspx). I have removed imenu integration (doesn't work) and moz integration [diff](https://github.com/ananthakumaran/tide/commit/9bf675fd9d00dbded4f33c46f981d7a47691e1d7)

link: http://github.com/ananthakumaran/typescript.el

reference: https://github.com/milkypostman/melpa/pull/2838