### PR TITLE
Add a recipe for auth-password-store

### DIFF
--- a/recipes/auth-password-store
+++ b/recipes/auth-password-store
@@ -1,0 +1,1 @@
+(auth-password-store :fetcher github :repo "DamienCassou/auth-password-store")


### PR DESCRIPTION
This PR adds a recipe for https://github.com/DamienCassou/auth-password-store.

`auth-password-store` implements an `auth-sources` backend for [pass](http://www.passwordstore.org/).