### PR TITLE
Adds a recipe for pass-mode

### DIFF
--- a/recipes/pass
+++ b/recipes/pass
@@ -1,0 +1,1 @@
+(pass :fetcher github :repo "NicolasPetton/pass")

--- a/recipes/pass-mode
+++ b/recipes/pass-mode
@@ -1,1 +1,0 @@
-(pass-mode :fetcher github :repo "NicolasPetton/pass-mode")

--- a/recipes/pass-mode
+++ b/recipes/pass-mode
@@ -1,0 +1,1 @@
+(pass-mode :fetcher github :repo "NicolasPetton/pass-mode")


### PR DESCRIPTION
This PR add a recipe for https://github.com/NicolasPetton/pass-mode.

`pass-mode` implements a major-mode for [pass](http://www.passwordstore.org/), displaying a dirctory-like list of the keychain entries.