### PR TITLE
Add helm-ls-svn recipe

### DIFF
--- a/recipes/helm-ls-svn
+++ b/recipes/helm-ls-svn
@@ -1,0 +1,1 @@
+(helm-ls-svn :fetcher svn :url "https://svn.macports.org/repository/macports/users/chunyang/helm-ls-svn.el")


### PR DESCRIPTION
helm-ls-svn (https://svn.macports.org/repository/macports/users/chunyang/helm-ls-svn.el/) is a helm extension for listing buffers/files under a svn repo, its purpose is the same as helm-ls-git and helm-ls-hg, but for svn. I am the author and maintainer..