### PR TITLE
update evil recipe url

### DIFF
--- a/recipes/evil
+++ b/recipes/evil
@@ -1,1 +1,1 @@
-(evil :url "https://gitorious.org/evil/evil.git" :fetcher git)
+(evil :url "https://bitbucket.org/lyro/evil" :fetcher hg)


### PR DESCRIPTION
The old url host has ceased as a service (https://gitorious.org/). The new url is that of the maintainer.