### PR TITLE
Updated repository for the tablist package

### DIFF
--- a/recipes/tablist
+++ b/recipes/tablist
@@ -1,5 +1,3 @@
 (tablist
  :fetcher github
- :repo "politza/pdf-tools"
- :files ("lisp/tablist.el"
-         "lisp/tablist-filter.el"))
+ :repo "politza/tablist")


### PR DESCRIPTION
I want to seperate this package from the pdf-tools repo, which would ease maintenance.  

