### PR TITLE
remove mode-line-in-header

### DIFF
--- a/recipes/mode-line-in-header
+++ b/recipes/mode-line-in-header
@@ -1,1 +1,0 @@
-(mode-line-in-header :fetcher github :repo "EricCrosson/mode-line-in-header")


### PR DESCRIPTION
In response to milkypostman/melpa#2868, this commit removes the recipe for a repo that no longer exists.