### PR TITLE
Add recipe for electric-operator

### DIFF
--- a/recipes/electric-operator
+++ b/recipes/electric-operator
@@ -1,0 +1,2 @@
+(electric-operator :repo "davidshepherd7/electric-operator"
+                   :fetcher github)


### PR DESCRIPTION
Electric operator is a minor mode which automatically adds spacing
around operators, e.g. `a=b+c` becomes `a = b + c`.

The repository is https://github.com/davidshepherd7/electric-operator

I'm the maintainer of the package.

However the package itself is a rewrite/fork of electric-spacing. The
functionality has increased significantly compared to electric-spacing,
but some additional dependencies were introduced. The author of
electric-spacing (William Xu, https://github.com/xwl,
william.xwl@gmail.com) preferred to keep electric-spacing free of any
dependencies, but he is happy for me to release this as a separate
package.