### PR TITLE
Fix omnisharp using outdated branch

### DIFF
--- a/recipes/omnisharp
+++ b/recipes/omnisharp
@@ -1,6 +1,6 @@
 (omnisharp :repo "OmniSharp/omnisharp-emacs"
            :fetcher github
-           :branch "develop"
+           :branch "master"
            :files ("*.el"
                    "src/*.el"
                    "src/actions/*.el"))


### PR DESCRIPTION
The omnisharp recipe currently specifies the `develop` branch, but it seems that [omnisharp-emacs](https://github.com/OmniSharp/omnisharp-emacs) is now merging additions into master and develop has fallen behind. This means the melpa-installed version of omnisharp currently doesn't work with omnisharp-roslyn on OS X and Linux, which has succeeded the original omnisharp-server.