### PR TITLE
Add highlight2clipboard

### DIFF
--- a/recipes/highlight2clipboard
+++ b/recipes/highlight2clipboard
@@ -1,0 +1,1 @@
+(highlight2clipboard :repo "Lindydancer/highlight2clipboard" :fetcher github :files (:defaults "bin"))


### PR DESCRIPTION
This is a little tool that exports a htmlized version of a text to the clipboard. Effectively, this mean that you can paste syntax highlighted text into word processors like Word and Pages or mail applications like gmail.

You can either run specific command to copy highlighted text to the clipboard, or you can enable Highlight2clipboard mode. When enabled, a htmlized version of any cut or copied text will be added to the clipboard.

Currently, this only work in MS-Windows and Mac OS X.
