### PR TITLE
Add key-seq recipe

### DIFF
--- a/recipes/key-seq
+++ b/recipes/key-seq
@@ -1,0 +1,3 @@
+(key-seq
+ :fetcher github
+ :repo "vlevit/key-seq.el")


### PR DESCRIPTION
key-seq provides similar functions to key-chord (and depends on it), but honors the order of specified keys, so there are much more "safe" key combinations.