### PR TITLE
add recipe for on-parens

### DIFF
--- a/recipes/on-parens
+++ b/recipes/on-parens
@@ -1,0 +1,3 @@
+(on-parens
+  :repo "willghatch/emacs-on-parens"
+  :fetcher github)


### PR DESCRIPTION
On-parens is a wrapper for smartparens for use in evil-normal-state.  It supplies sexp movement commands that work the way I feel such movements should work in vim/evil, respecting the notion of the cursor being on a character rather than between characters.

It's pretty hacky and I mostly threw most of it together in a few hours this morning, but I've been looking for a package like this forever, and I figure someone else may want this as well.