### PR TITLE
Update JonPRL mode with icon

### DIFF
--- a/recipes/jonprl-mode
+++ b/recipes/jonprl-mode
@@ -1,1 +1,4 @@
-(jonprl-mode :fetcher github :repo "david-christiansen/jonprl-mode")
+(jonprl-mode
+ :fetcher github
+ :repo "david-christiansen/jonprl-mode"
+ :files (:defaults "jonprl-icon.png"))


### PR DESCRIPTION
JonPRL mode now has a toolbar, and its toolbar icon needs to be downloaded with it.