### PR TITLE
Add recipe for magit/ssh-agency

### DIFF
--- a/recipes/ssh-agency
+++ b/recipes/ssh-agency
@@ -1,0 +1,1 @@
+(ssh-agency :fetcher github :repo "magit/ssh-agency")


### PR DESCRIPTION
This package handles starting ssh-agent and accessing it from Emacs on `windows-nt` systems (see also https://github.com/magit/magit/wiki/Pushing-with-Magit-from-Windows)

repo: https://github.com/magit/ssh-agency.git

I'm the author of this package.