### PR TITLE
Add recipe for prop-menu.el

### DIFF
--- a/recipes/prop-menu
+++ b/recipes/prop-menu
@@ -1,0 +1,1 @@
+(prop-menu :fetcher github :repo "david-christiansen/prop-menu-el")


### PR DESCRIPTION
`prop-menu.el` is an library for computing contextual menus from text
properties and overlay properties. In particular, it's developed for
`idris-mode`, where the compiler sends quite a lot of semantic annotations
about the source code back to Emacs. This will allow relevant commands,
such as documentation lookup, case-splitting pattern variables, and
showing error details, to be built for each location in the
buffer, with a single keybinding or mouse click giving easy access to
the commands. Since I think this may be useful outside of `idris-mode`, I'm
submitting it as a separate library.

The package repository is at https://www.github.com/david-christiansen/prop-menu-el.