### PR TITLE
Add a recipe for zerodark-theme

### DIFF
--- a/recipes/zerodark-theme
+++ b/recipes/zerodark-theme
@@ -1,0 +1,1 @@
+(zerodark-theme :fetcher github :repo "NicolasPetton/zerodark-theme")


### PR DESCRIPTION
## summary

This theme is a dark, medium-contrast theme inspired from [Niflheim](https://github.com/niflheim-theme/emacs) and [One Dark](https://github.com/atom/one-dark-syntax).

![screenshot](https://cloud.githubusercontent.com/assets/123539/8483526/72e843c2-20f1-11e5-9466-7bf0965b87c4.png)

## Infos about this package

- [Homepage](https://github.com/NicolasPetton/zerodark-theme) on GitHub
- Author: me (Nicolas Petton)

- `make recipes/zerodark-theme` works without any issue
- The package installs properly via `package-install-file`