### PR TITLE
Add recipe for ioccur.

### DIFF
--- a/recipes/ioccur
+++ b/recipes/ioccur
@@ -1,0 +1,1 @@
+(ioccur :fetcher github :repo "thierryvolpiatto/ioccur")


### PR DESCRIPTION
Request inclusion (re) of ioccur in Melpa.
It seems it have been removed.
The version available on Elpa is not up to date and I do not maintain it anymore.
Even if this package is predated by helm-(m)occur, I would like to keep providing a usable version.

Thanks.