### PR TITLE
Added recipe for paren-completer

### DIFF
--- a/recipes/paren-completer
+++ b/recipes/paren-completer
@@ -1,0 +1,1 @@
+(paren-completer :repo "MatthewBregg/paren-completer" :fetcher github)


### PR DESCRIPTION

1 A brief summary of what the package does.
===========================================

  This package enables one to insert the next closing delimiter, with a
  single command, or insert all unmatched delimiters.


2 A direct link to the package repository.
==========================================

  https://github.com/MatthewBregg/paren-completer


3 Your association with the package (e.g., are you the maintainer? have you contributed? do you just like the package a lot?).
==============================================================================================================================

  I am the creator of the package


4 Testing
=========

  I tested the package via
  ,----
  | make recipes/paren-completer
  `----
  and then installed via a fresh emacs -q, and from the make sandbox.
