### PR TITLE
Update peg recipe to use new github repository

### DIFF
--- a/recipes/peg
+++ b/recipes/peg
@@ -1,1 +1,1 @@
-(peg :fetcher wiki)
+(peg :fetcher github :repo "ellerh/peg.el")


### PR DESCRIPTION
This was brought on by a desire to get out a stable release for `edn.el` which depends on `peg.el` as discussed [here](https://github.com/expez/edn.el/issues/4).