### PR TITLE
add a recipe for ace-popup-menu

### DIFF
--- a/recipes/ace-popup-menu
+++ b/recipes/ace-popup-menu
@@ -1,0 +1,1 @@
+(ace-popup-menu :repo "mrkkrp/ace-popup-menu" :fetcher github)


### PR DESCRIPTION
This package allows to replace GUI popup menu (created by `x-popup-menu` by default) with little temporary window (like that in which Dired shows you files you want to copy). In this window, menu items are displayed and labeled with one or two letters. You press a key corresponding to desired choice (or <kbd>C-g</kbd>) and you are done.

More information is available here:

https://github.com/mrkkrp/ace-popup-menu