### PR TITLE
Add recipe for go-dlv.

### DIFF
--- a/recipes/go-dlv
+++ b/recipes/go-dlv
@@ -1,0 +1,1 @@
+(go-dlv :repo "benma/go-dlv.el" :fetcher github)


### PR DESCRIPTION
I am the author of the package. The packager url is https://github.com/benma/go-dlv.el.
The package lets you use the Go Delve debugger (https://github.com/derekparker/delve/) with Emacs' GUD (grand unified debugger).