### PR TITLE
add babeljs-repl package

### DIFF
--- a/recipes/babel-repl
+++ b/recipes/babel-repl
@@ -1,0 +1,1 @@
+(babel-repl :fetcher github :repo "hung-phan/babel-repl")

--- a/recipes/babeljs-repl
+++ b/recipes/babeljs-repl
@@ -1,1 +1,0 @@
-(babeljs-repl :fetcher github :repo "hung-phan/babeljs-repl.el")

--- a/recipes/babeljs-repl
+++ b/recipes/babeljs-repl
@@ -1,0 +1,1 @@
+(babeljs-repl :fetcher github :repo "hung-phan/babeljs-repl.el")


### PR DESCRIPTION
I create a package for emacs to support for javascript compiler (https://babeljs.io) in https://github.com/hung-phan/babeljs-repl.el/.