### PR TITLE
add haskell-emacs-text

### DIFF
--- a/recipes/haskell-emacs-text
+++ b/recipes/haskell-emacs-text
@@ -1,0 +1,4 @@
+(haskell-emacs-text :fetcher github
+                    :repo "knupfer/haskell-emacs"
+                    :files ("modules/text/*.el" "modules/text/*.hs"
+                            (:exclude "*-test.el" "*Test.hs")))


### PR DESCRIPTION
I'm the maintainer and have run tests etc.  This is a library for
`haskell-emacs` which provides nearly all of the Data.Text haskell lib
as elisp-macros (they communicate with a haskell process).

Usage:
```
(require 'haskell-emacs-text)
(haskell-emacs-init)

(Text.append "a" "b")
  => "ab"
```
It would be more convenient to have something like
```
;;;###autoload (haskell-emacs-register-module)
```
so an installed module would immediately register for `haskell-emacs`. This would use nearly no resources, but would defeat the autoload of `haskell-emacs` and prevent the user from chosing.

So now, the user has to require this library explicitly in his `.emacs` before calling `haskell-emacs-init`.  Or should I be less conservative?