### PR TITLE
add haskell-emacs-base.el

### DIFF
--- a/recipes/haskell-emacs-base
+++ b/recipes/haskell-emacs-base
@@ -1,0 +1,4 @@
+(haskell-emacs-base :fetcher github
+                    :repo "knupfer/haskell-emacs"
+                    :files ("modules/base/*.el" "modules/base/*.hs"
+                            (:exclude "*-test.el" "*Test.hs")))


### PR DESCRIPTION
I'm the author. Compare with other pullrequest concerning `haskell-emacs-text.el`

This library adds a lot of haskell functions from the Prelude to
`haskell-emacs`.