### PR TITLE
Add recipe for ‘highlight-line’

### DIFF
--- a/recipes/highlight-line
+++ b/recipes/highlight-line
@@ -1,0 +1,1 @@
+(highlight-line :repo "mrkkrp/highlight-line" :fetcher github)


### PR DESCRIPTION
Continuing extracting of usable packages from my init files :-) This is rather tiny one.

Here is description:

https://github.com/mrkkrp/highlight-line

At first I thought that people could just add a bunch of hooks and this doesn't need to be a package, but later I recognized convenience of getting all the stuff done for you, so nothing is forgotten and thus user experience is consistent. It's also useful to have it as a minor mode, so you can turn it on/off without pain.