### PR TITLE
Add "python-x".

### DIFF
--- a/recipes/python-x
+++ b/recipes/python-x
@@ -1,0 +1,2 @@
+(python-x :repo "wavexx/python-x.el"
+          :fetcher github)


### PR DESCRIPTION
From the Commentary:
````
;; python-x extends the built-in `python-mode' (F. Gallina's) with several
;; additional functions and behaviors inspired by `ess-mode', which are
;; targeted to interactive code evaluation with an inferior Python process.
;;
;; python-x allows to evaluate code blocks using comments as delimiters (code
;; "sections") or using arbitrarily nested folding marks.
;;
;; python-x installs an handler to show uncaught exceptions produced by
;; interactive code evaluation by default. See `python-shell-show-exceptions'
;; to control this behavior.
;;
;; The following functions are introduced:
;; - `python-shell-send-line': evaluate and print the current line, accounting
;;   for statement and line continuations.
;; - `python-shell-send-line-and-step': evaluate and current line as above,
;;   then move the point to the next automatically.
;; - `python-shell-send-fold-or-section': evaluate the region defined by the
;;   current code fold or section.
;; - `python-shell-send-dwim': evaluate the active region when active,
;;   otherwise revert to the current fold or section.
;;
;; python-x uses `volatile-highlights' for highlighting. Installation through
;; "melpa" is recommended (you don't actually need to enable
;; `volatile-highlights-mode' itself). `folding-mode' is similarly required (on
;; Debian it can be installed through the "emacs-goodies-el" package).
;;
;; Read through the Usage section in the source file for usage instructions and
;; recommended keybindings.
````