### PR TITLE
Add recipe for fm-bookmarks

### DIFF
--- a/recipes/fm-bookmarks
+++ b/recipes/fm-bookmarks
@@ -1,0 +1,1 @@
+(fm-bookmarks :repo "kuanyui/fm-bookmarks.el" :fetcher github)


### PR DESCRIPTION
[fm-bookmarks.el](https://github.com/kuanyui/fm-bookmarks.el) allow you access existed File Managers' bookmarks (e.g. Dolphin, Nautilus, PCManFM) in Dired