### PR TITLE
Add which-key recipe

### DIFF
--- a/recipes/which-key
+++ b/recipes/which-key
@@ -1,0 +1,3 @@
+(which-key :repo "justbur/emacs-which-key"
+           :fetcher github)
+


### PR DESCRIPTION
This is a rewrite of guide-key-mode for emacs. The intention is to provide the following features:

1. A different polling mechanism to make it lighter on resources than guide-key
2. An improved display of keys with more keys being shown by default and a nicer presentation
3. Customization options that allow for the rewriting of command names on the fly through easily modifiable alists
4. Good default configurations that work well with most themes
5. A well configured back-end for displaying keys (removing the popwin dependency) that can be easily customized by writing new display functions

Link: https://github.com/justbur/emacs-which-key

I'm the author and maintainer. Thanks!