### PR TITLE
Add 'folding' (folding-mode).

### DIFF
--- a/recipes/folding
+++ b/recipes/folding
@@ -1,0 +1,2 @@
+(folding :repo "jaalto/project-emacs--folding-mode"
+         :fetcher github)


### PR DESCRIPTION
This is "folding.el", the classical comment-based folding mode that I normally use through the Debian's emacs-goodies-el package. It used to be on Savannah, but I just discovered it moved to github and it's more recent.

Here's the recipe for it. Commentary is _long_ and there's no version tag, but other than that it looks good.