### PR TITLE
Emacs port of JuneGunn's Seoul256 vim colour theme

### DIFF
--- a/recipes/seoul256-theme
+++ b/recipes/seoul256-theme
@@ -1,0 +1,1 @@
+(seoul256-theme :fetcher github :repo "ChrisDavison/seoul256.el")


### PR DESCRIPTION
As title suggests, taking @junegunn MIT licensed Seoul256 theme and converting from Vim to Emacs.  

Currently only dark theme is supported, but may expand to light theme in the future.