### PR TITLE
Add recipe for cinspect-mode

### DIFF
--- a/recipes/cinspect
+++ b/recipes/cinspect
@@ -1,0 +1,3 @@
+(cinspect
+ :fetcher github
+ :repo "inlinestyle/cinspect-mode")


### PR DESCRIPTION
Hi! I'd like to add a recipe for [cinspect-mode](https://github.com/inlinestyle/cinspect-mode).
 - `cinspect-mode` gives an emacs user easy access to the [cinspect](https://github.com/punchagan/cinspect) project (source code inspection for CPython builtins).
 - I am the creator and maintainer. 
 - I've tested and verified that the package builds and installs in the MELPA sandbox

Please let me know if there's any other info you need.