### PR TITLE
Add recipe for ‘mmt’

### DIFF
--- a/recipes/mmt
+++ b/recipes/mmt
@@ -1,0 +1,1 @@
+(mmt :repo "mrkkrp/mmt" :fetcher github)


### PR DESCRIPTION
This is [Missing Macro Tools](https://github.com/mrkkrp/mmt), `mmt`. This contains the following classics implemented in Emacs Lisp:

* `mmt-gensym`
* `mmt-make-gensym-list`
* `mmt-with-gensyms`
* `mmt-with-unique-names`
* `mmt-once-only`

This should be ample for a start.

`mmt` name is chosen because

* it needs to be short, because it's collection of utilities for Emacs Lisp developers;
* it's impossible to choose sufficiently short and at the same time descriptive name;
* three letters are OK, as I understand.

I didn't plan to write it, but I needed `with-gensyms` and there is no such thing or library that provides it. Org developers even had to write their own version `org-with-gensyms`. This shows that such a library is necessary.

I asked [question](http://emacs.stackexchange.com/questions/14031/gensyms-in-emacs-lisp) on Emacs Stack Exchange and people started to tell me first to copy-paste it everywhere I need it (they obviously thought that I just don't know how to code it or something) or use the `org-with-gensyms` (after I told them about it with intention to demonstrate that it's not normal when standard primitives are reinvented everywhere people need them, `org-with-gensyms` is undocumented ad-hoc thing that's clearly not part of `org` API and `org` is not library of such tools by its nature). I cannot build something the way they advise, I need normal library to depend upon and use everywhere I want.

If you can suggest better name, please do.