### PR TITLE
add rcirc-styles package at v1.1

### DIFF
--- a/recipes/rcirc-styles
+++ b/recipes/rcirc-styles
@@ -1,3 +1,3 @@
 (rcirc-styles :fetcher github
               :repo "aaron-em/rcirc-styles.el"
-              :commit "refs/tags/v1.0")
+              :commit "refs/tags/v1.1")

--- a/recipes/rcirc-styles
+++ b/recipes/rcirc-styles
@@ -1,3 +1,2 @@
 (rcirc-styles :fetcher github
-              :repo "aaron-em/rcirc-styles.el"
-              :commit "refs/tags/v1.1")
+              :repo "aaron-em/rcirc-styles.el")

--- a/recipes/rcirc-styles
+++ b/recipes/rcirc-styles
@@ -1,0 +1,3 @@
+(rcirc-styles :fetcher github
+              :repo "aaron-em/rcirc-styles.el"
+              :commit "refs/tags/v1.0")


### PR DESCRIPTION
This package implements correct and complete handling of mIRC-style color and attribute codes for rcirc, obsoleting the pre-existing MELPA package "rcirc-controls".

(I tried to fix the many bugs in that package first, I really did! But they turned out to be so intractable that a rewrite was the more sensible option. Those bugs are listed in the readme for rcirc-styles; take a look, I think you'll see what I mean.)

Its repository is at https://github.com/aaron-em/rcirc-styles.el; I am the implementer and maintainer.

To the best of my ability, I tested that this package correctly builds and installs from MELPA, per the instructions in the readme. I did have some trouble with the "make sandbox" invocation:

    Aaron@emacs-vm melpa $ EMACS=`which emacs` make sandbox
    make: *** No rule to make target `packages/*.entry', needed by `packages/archive-contents'.  Stop.

As far as I can tell, though, that's not due to the package or my environment; perhaps you can provide some insight there. (I have some other packages which I'd like to contribute, but I'll hold off opening PRs for them until I've got this issue sorted out.)