### PR TITLE
Add eshell-z recipe

### DIFF
--- a/recipes/eshell-z
+++ b/recipes/eshell-z
@@ -1,0 +1,1 @@
+(eshell-z :fetcher github :repo "xuchunyang/eshell-z")


### PR DESCRIPTION
Repo link: https://github.com/xuchunyang/eshell-z.

eshell-z is a eshell version of https://github.com/rupa/z, it keeps track of where you’ve been and how many commands you invoke there, and provides a convenient way to jump to the directories you actually use. eshell-z and z can work together by using the same database.