### PR TITLE
Add recipe for company-irony-c-headers

### DIFF
--- a/recipes/company-irony-c-headers
+++ b/recipes/company-irony-c-headers
@@ -1,0 +1,2 @@
+(company-irony-c-headers :fetcher github
+                         :repo "hotpxl/company-irony-c-headers")


### PR DESCRIPTION
I am the author of [company-irony-c-headers](https://github.com/hotpxl/company-irony-c-headers).

It is a backend for [company-mode](https://github.com/company-mode/company-mode). It completes C/C++ header files, with compiler options provided by [irony-mode](https://github.com/Sarcasm/irony-mode/).

BTW. I'm getting "package-buffer-info: Package lacks a file header" when I'm trying to `make` the recipe. I don't really know what is missing. Could you tell me what's amiss?