### PR TITLE
Filtered out test file in ponylang recipe.

### DIFF
--- a/recipes/ponylang-mode
+++ b/recipes/ponylang-mode
@@ -1,1 +1,3 @@
-(ponylang-mode :fetcher github :repo "abingham/ponylang-mode")
+(ponylang-mode :fetcher github
+               :repo "abingham/ponylang-mode"
+               :files "ponylang-mode.el")


### PR DESCRIPTION
We just added the skeleton for a testsuite to ponylang-mode, and I
figured melpa users didn't need to get the source for the test files.