### PR TITLE
Add recipe for ‘ebal’

### DIFF
--- a/recipes/ebal
+++ b/recipes/ebal
@@ -1,0 +1,1 @@
+(ebal :repo "mrkkrp/ebal" :fetcher github)


### PR DESCRIPTION
This is Emacs interface to Cabal. More information is here: https://github.com/mrkkrp/ebal