### PR TITLE
Set <title> tag with the title of the current page on melpa.org

### DIFF
--- a/html/js/melpa.js
+++ b/html/js/melpa.js
@@ -368,6 +368,7 @@
     var badgeURL = melpa.rootURL + pkg.badgeURL;
     var fullURL = melpa.rootURL + packagePath(pkg);
 
+    document.title = pkg.name +  " " + pkg.version + " | " + (new melpa.archivename.controller()).archiveName();
     return m("section", [
       m("h1", [pkg.name, " ", m("small", pkg.version)]),
       m("p.lead", pkg.description),
@@ -460,7 +461,6 @@
   };
 
   document.addEventListener("DOMContentLoaded", function() {
-    document.title = (new melpa.archivename.controller()).archiveName();
     _.each(document.getElementsByClassName('archive-name'), function (e) {
       // jshint unused: false
       m.mount(e, melpa.archivename);
@@ -474,7 +474,7 @@
   // Static pages
   //////////////////////////////////////////////////////////////////////////////
 
-  melpa.staticpage = function(partialPath) {
+  melpa.staticpage = function(partialPath, title) {
     this.controller = function() {
       this.content = m.prop('');
       m.request({method: "GET", url: partialPath,
@@ -482,6 +482,7 @@
                 }).then(this.content);
     };
     this.view = function(ctrl) {
+      document.title = title + " | " + (new melpa.archivename.controller()).archiveName();
       return m("div", [m.trust(ctrl.content())]);
     };
   };
@@ -498,6 +499,7 @@
     this.archivename = new melpa.archivename.controller();
   };
   melpa.frontpage.view = function(ctrl) {
+    document.title = (new melpa.archivename.controller()).archiveName();
     return m("div", [
       m("section.page-header", [
         m("h1", [
@@ -532,7 +534,7 @@
   //////////////////////////////////////////////////////////////////////////////
   // Routing
   //////////////////////////////////////////////////////////////////////////////
-  melpa.gettingstarted = new melpa.staticpage("/partials/getting-started.html");
+  melpa.gettingstarted = new melpa.staticpage("/partials/getting-started.html", "Getting Started");
 
   m.route.mode = "hash";
   m.route(document.getElementById("content"), "/", {


### PR DESCRIPTION
This PR sets the `<title>` tag with the title of the current page. So if you're on a specific package's page you'll actually see that package's name+version in your browser's tab and more importantly when you're going through your browser history (which was my motivation for this PR).

![image](https://cloud.githubusercontent.com/assets/31308/8938824/c41b380c-3515-11e5-9afb-a31f188d1108.png)

Right now it's using `|` as the separator and I am not 100% sure version should be part of the title, but I do think something like this should be done regardless of style/content decisions. Thoughts?

This PR was tested on the most recent versions of Chrome, Firefox, and Safari on a Mac.