### PR TITLE
Add a recipe for dictcc.el

### DIFF
--- a/recipes/dictcc
+++ b/recipes/dictcc
@@ -1,0 +1,1 @@
+(dictcc :repo "cqql/dictcc.el" :fetcher github)


### PR DESCRIPTION
Hi,
I would like to add a recipe to an interface for [dict.cc](http://dict.cc).

The problem is, that it does not build correctly on my computer. Trying `C-c C-c` in the recipe buffer produces
```lisp
;; Please check the following package descriptor.
;; If the correct package description or dependencies are missing,
;; then the source .el file is likely malformed, and should be fixed.
(dictcc .
        [(20150730 2315)
         nil "No description available." single nil])
```
So somehow it is unable to read the description and dependencies of the project. But I have no idea, what is going wrong. Maybe it fails because of the `-*- lexical-binding: t; -*-`?

Repository: https://github.com/cqql/dictcc.el