### PR TITLE
Go to page 1 on search change

### DIFF
--- a/html/js/melpa.js
+++ b/html/js/melpa.js
@@ -286,7 +286,10 @@
       m("p", [
         m("input.form-control[type=search]", {
           placeholder: "Enter filter terms", autofocus: true,
-          value: ctrl.filterTerms(), onkeyup: m.withAttr("value", ctrl.filterTerms)
+          value: ctrl.filterTerms(), onkeyup: m.withAttr("value", function(value) {
+            ctrl.filterTerms(value);
+            ctrl.paginatorCtrl.pageNumber(1);
+          })
         }),
         " ",
         m("span.help-block", [ctrl.matchingPackages().length, " matching package(s)"])


### PR DESCRIPTION
This fixes an issue on http://melpa.org/ where if you navigate to a page past 1 on the list of packages and then decide you want to filter packages you'll potentially see no results.

Example: Click to go to page 3 on http://melpa.org/ and then filter by `zz`. No results  will be shown because you're still on the third page even though there is actually 15 packages to show.

This PR simply forces you to page 1 when you change your filter.