### PR TITLE
Add 'virtual-shift-tabs

### DIFF
--- a/recipes/virtual-shift-tabs
+++ b/recipes/virtual-shift-tabs
@@ -1,0 +1,2 @@
+(virtual-shift-tabs :repo "wavexx/virtual-shift-tabs.el"
+                    :fetcher github)


### PR DESCRIPTION
From the commentary:

````
;; The function `virtual-shift-tabs' adjusts the visual alignment of TABs in
;; major modes displaying unified diffs (such as `diff-mode', `magit-diff',
;; etc) to compensate for the initial +/- prefix.
;;
;; To enable in the various magit modes, use the following:
;;
;; (add-hook 'magit-refresh-buffer-hook
;;           (lambda ()
;;             (when (member major-mode '(magit-diff-mode magit-revision-mode))
;;               (virtual-shift-tabs))))
````