### PR TITLE
Added a recipe for runtests

### DIFF
--- a/recipes/runtests
+++ b/recipes/runtests
@@ -1,0 +1,1 @@
+(runtests :fetcher github :repo "sunesimonsen/emacs-runtests")


### PR DESCRIPTION
This pull request adds a recipe for my package runtests.

This Emacs extension will run an external script called runtests that should be in your path. If the script fails the output of the script will be shown with ansi colors. Simple and useful.

https://github.com/sunesimonsen/emacs-runtests/

Let me know if I'm submitting this the wrong way, this is my first Melpa package.

Kind regards
Sune