### PR TITLE
Add recipe for "rigid-tabs"

### DIFF
--- a/recipes/rigid-tabs
+++ b/recipes/rigid-tabs
@@ -1,0 +1,2 @@
+(rigid-tabs :repo "wavexx/rigid-tabs.el"
+            :fetcher github)


### PR DESCRIPTION
From the commentary:

Unified diffs introduce one or more prefix characters that alter the target
column of the displayed TABs. The resulting misalignment may make code
indentation look suspicious and overall harder to read, even though it's
perfectly aligned when the patch is applied.

``rigid-tabs-mode`` "rigidifies" all TABs in the current buffer, preserving
their width but making them non-flexible just like a block of spaces. This
allows TABs to be shifted without changing their width.

The function ``rigid-tabs-rigid-align`` turns on ``rigid-tabs-mode`` and
adjusts the visual alignment of TABs in major modes displaying unified diffs
(such as ``diff-mode``, ``magit-diff``, etc) to compensate for the initial +/-
prefix. The result is a diff that looks indented as if applied on the source.

https://github.com/wavexx/rigid-tabs.el