### PR TITLE
[new] ox-mediawiki recipe

### DIFF
--- a/recipes/ox-mediawiki
+++ b/recipes/ox-mediawiki
@@ -1,0 +1,2 @@
+(ox-mediawiki :fetcher github
+              :repo "tomalexander/orgmode-mediawiki")


### PR DESCRIPTION
Hello,

- Repository: https://github.com/tomalexander/orgmode-mediawiki
- Package permits to export org-mode to mediawiki text 
- I'm not the maintainer. I'm a user.
- Compiled with the emacs buffer and installed it -> all good
- Notified the maintainer https://github.com/tomalexander/orgmode-mediawiki/issues/12

Cheers,