### PR TITLE
pmdm.el is a simple alternative to desktop-mode for storing and opening files

### DIFF
--- a/recipes/pmdm
+++ b/recipes/pmdm
@@ -1,1 +1,1 @@
-(per-buffer-theme :fetcher hg :url "https://bitbucket.org/inigoserna/pmdm.el")
+(pmdm :fetcher hg :url "https://bitbucket.org/inigoserna/pmdm.el")

--- a/recipes/pmdm
+++ b/recipes/pmdm
@@ -1,0 +1,1 @@
+(per-buffer-theme :fetcher hg :url "https://bitbucket.org/inigoserna/pmdm.el")


### PR DESCRIPTION
pmdm.el - poor man's desktop-mode - is a simple alternative to desktop-mode for storing and opening loaded files.

Run *pmdm/write-opened-files* manually or in a hook before quitting emacs to save the files you want to restore later and *pmdm/load-files* to open the stored files again.

Customizable variable *pmdm/file-name* contains the name of the file used to store the files list.