### PR TITLE
Change nim-mode's repository

### DIFF
--- a/recipes/nim-mode
+++ b/recipes/nim-mode
@@ -1,4 +1,3 @@
 (nim-mode :fetcher github
-          :repo "reactormonk/nim-mode"
-          :files ("nim-mode.el")
+          :repo "nim-lang/nim-mode"
           :old-names (nimrod-mode))


### PR DESCRIPTION
Hi, nim-mode's repository moved to [here](https://github.com/nim-lang/nim-mode) and now the package has several files, so I just changed the recipe accordingly.