### PR TITLE
Enable Snippet support for nand2tetris package

### DIFF
--- a/recipes/nand2tetris
+++ b/recipes/nand2tetris
@@ -1,2 +1,3 @@
 (nand2tetris :fetcher github
-               :repo "CestDiego/nand2tetris.el")
+             :repo "CestDiego/nand2tetris.el"
+             :files (:defaults "snippets"))


### PR DESCRIPTION
I added YASnippet support and so I need to also load the snippets in the
recipe. Sorry for the inconvenience