### PR TITLE
Add sly-named-readtables

### DIFF
--- a/recipes/sly-named-readtables
+++ b/recipes/sly-named-readtables
@@ -1,0 +1,5 @@
+(sly-named-readtables :fetcher github
+		      :repo "capitaomorte/sly-named-readtables"
+		      :files (:defaults
+			      "*.lisp"
+			      "*.asd"))


### PR DESCRIPTION
This package enables support for the Common Lisp system NAMED-READTABLES in the SLY IDE. This system's special IN-READTABLE macro is understood by the IDE and used to compile parts of the file
in a special way.

Available at http://github.com/capitaomorte/sly-named-readtables

I'm the maintainer, and I tested this with:

    git clean -fdx
    make recipes/sly-named-readtables
    make sandbox
    M-x package-install sly-named-readtables ; installs SLY as well
    M-x sly-setup                            ; needed only this time
    M-x sly                                  ; launches SLY