### PR TITLE
add angularjs-mode recipe

### DIFF
--- a/recipes/angularjs-mode
+++ b/recipes/angularjs-mode
@@ -1,0 +1,5 @@
+(angularjs-mode
+ :fetcher github
+ :repo "omouse/angularjs-mode"
+ :files (:defaults
+         "snippets"))


### PR DESCRIPTION
angularjs-mode is a major mode for Angular.js projects. Its official repo is at https://github.com/omouse/angularjs-mode

I found this package useful and should be in MELPA.

Made some modifications in the original repo and hope this is sufficient to make it into MELPA.