### PR TITLE
Add jq-mode

### DIFF
--- a/recipes/jq-mode
+++ b/recipes/jq-mode
@@ -1,0 +1,1 @@
+(jq-mode :repo "ljos/jq-mode" :fetcher github)


### PR DESCRIPTION
jq-mode is a new mode for writing jq scripts in Emacs.