### PR TITLE
Add recipe for JDEE

### DIFF
--- a/recipes/jdee
+++ b/recipes/jdee
@@ -1,0 +1,1 @@
+(jdee :fetcher github :repo "jdee-emacs/jdee")


### PR DESCRIPTION
It's Java Development Environment for Emacs.
The repository is here: https://github.com/jdee-emacs/jdee
I'm a maintainer of the package.
I've tested the package and it works.