### PR TITLE
Add recipe for evil-quickscope

### DIFF
--- a/recipes/evil-quickscope
+++ b/recipes/evil-quickscope
@@ -1,0 +1,1 @@
+(evil-quickscope :repo "blorbx/evil-quickscope" :fetcher github)


### PR DESCRIPTION
`evil-quickscope` highlights targets for evil-mode's f,F,t, and T keys.
The repository can be found at https://github.com/blorbx/evil-quickscope
I'm the package maintainer.
I tested the package and it builds and installs OK.
Thanks!
