### PR TITLE
Adding git-record-mode

### DIFF
--- a/recipes/git-record-mode
+++ b/recipes/git-record-mode
@@ -1,0 +1,1 @@
+(git-record-mode :fetcher github :repo "alakra/git-record-mode")


### PR DESCRIPTION
Minor mode that automatically adds keystroke changes on a buffer to a git repository via `magit`.

See https://github.com/alakra/git-record-mode for package details.

NOTE: This differs from `git-auto-commit-mode` by hooking into buffer changes, not just when a buffer is saved.