### PR TITLE
add speech-tagger recipe

### DIFF
--- a/recipes/speech-tagger
+++ b/recipes/speech-tagger
@@ -1,0 +1,3 @@
+(speech-tagger :fetcher github :repo "cosmicexplorer/speech-tagger"
+               :files ("emacs/speech-tagger.el"
+                       "emacs/penn_treebank_tags.json"))

--- a/recipes/speech-tagger
+++ b/recipes/speech-tagger
@@ -1,5 +1,3 @@
 (speech-tagger :fetcher github :repo "cosmicexplorer/speech-tagger"
                :files ("emacs/speech-tagger.el"
-                       "emacs/penn_treebank_tags.json"
-                       "emacs/speech-tagger.jar")
-               :branch "melpa-build")
+                       "emacs/penn_treebank_tags.json"))

--- a/recipes/speech-tagger
+++ b/recipes/speech-tagger
@@ -1,3 +1,5 @@
 (speech-tagger :fetcher github :repo "cosmicexplorer/speech-tagger"
                :files ("emacs/speech-tagger.el"
-                       "emacs/penn_treebank_tags.json"))
+                       "emacs/penn_treebank_tags.json"
+                       "emacs/speech-tagger.jar")
+               :branch "melpa-build")


### PR DESCRIPTION
speech-tagger is an extension to tag parts of speech in an emacs buffer
using stanford coreNLP. It can be found at
https://github.com/cosmicexplorer/speech-tagger. I am the maintainer of
this package.