### PR TITLE
Add recipe for rustfmt

### DIFF
--- a/recipes/rustfmt
+++ b/recipes/rustfmt
@@ -1,0 +1,2 @@
+(rustfmt :fetcher github
+         :repo "fbergroth/emacs-rustfmt")


### PR DESCRIPTION
[rustfmt.el](https://github.com/fbergroth/emacs-rustfmt) formats code in rust buffers using [rustfmt](https://github.com/nrc/rustfmt).

Cheers