### PR TITLE
Adding a recipe for company-try-hard.

### DIFF
--- a/recipes/company-try-hard
+++ b/recipes/company-try-hard
@@ -1,0 +1,1 @@
+(company-try-hard :repo "Wilfred/company-try-hard" :fetcher github)


### PR DESCRIPTION
This package provides a single command that finds completion candidates more aggressively than `company-complete`. It's a feature I really miss from `hippie-expand` so I thought I'd code it up for company.