### PR TITLE
Add recipe for `desktop+`

### DIFF
--- a/recipes/desktop+
+++ b/recipes/desktop+
@@ -1,0 +1,1 @@
+(desktop+ :fetcher github :repo "ffevotte/desktop-plus")


### PR DESCRIPTION
[`desktop+`](https://github.com/ffevotte/desktop-plus)  extends `desktop` by providing more features related to sessions persistance:

1. Instead of relying on Emacs' starting directory to choose the session Emacs restarts, sessions are manipulated by name. All information about them is stored into a centralized directory.

2. Desktop sessions by default save only buffers associated to "real" files. Desktop+ extends this by handling also "special buffers", such as those in `compilation-mode` or `term-mode`.

