### PR TITLE
Add recipe for ‘zzz-to-char’

### DIFF
--- a/recipes/zzz-to-char
+++ b/recipes/zzz-to-char
@@ -1,0 +1,1 @@
+(zzz-to-char :repo "mrkkrp/zzz-to-char" :fetcher github)


### PR DESCRIPTION
This is `zzz-to-char`, a package to do “zzz” to specified char. It provides functions `zzz-to-char` and `zzz-up-to-char` similar to built-in ones but when your character of choice is ambiguous (i.e. there are several occurrences of the char around the point), you can select “destination” char with avy. Then text between the point and selected char is killed.

Works smoothly, you often don't need to specify particular occurrence (i.e. there is only one occurrence) since region where characters are scanned is quite limited (this is customizable).

Here is the repo: https://github.com/mrkkrp/zzz-to-char

Thanks!
