### PR TITLE
Added (and tested) recipe for `subemacs.el'

### DIFF
--- a/recipes/subemacs
+++ b/recipes/subemacs
@@ -1,0 +1,3 @@
+(subemacs :fetcher github :repo "kbauer/subemacs"
+          :files (:defaults
+                  (:exclude "*experimental*")))


### PR DESCRIPTION
`subemacs.el` provides functions for evaluating emacs-lisp code in a new `emacs -Q` subprocess, that inherits only the `load-path` of the current session.

This allows conveniently testing commands or compiling files unaffected by user configuration and loaded packages and e.g. helps identifying missing `require` statements.


Repository https://github.com/kbauer/subemacs

The package was created by me. 
