### PR TITLE
Add flycheck-status-emoji

### DIFF
--- a/recipes/flycheck-status-emoji
+++ b/recipes/flycheck-status-emoji
@@ -1,0 +1,3 @@
+(flycheck-status-emoji
+ :fetcher github
+ :repo "liblit/flycheck-status-emoji")


### PR DESCRIPTION
`flycheck-status-emoji` replaces the standard [Flycheck mode-line status indicators](http://www.flycheck.org/manual/latest/Mode-line-display.html#Mode-line-display) with cute, compact emoji that convey the corresponding information. For example, a buffer shows status “😔” while being checked, then “😱” to report errors, “😟” to report warnings, or “😌” if no problems were found.

I am the maintainer of this package. Its official repository is https://github.com/liblit/flycheck-status-emoji. I have tested that the package builds properly via `make recipes/flycheck-status-emoji`, installs properly into a `make sandbox` sandboxed Emacs via `package-install-file`, and runs properly in that sandbox once installed.