### PR TITLE
Adding mmm-jinja2 class

### DIFF
--- a/recipes/mmm-jinja2
+++ b/recipes/mmm-jinja2
@@ -1,0 +1,1 @@
+(mmm-jinja2 :repo "beardedprojamz/mmm-jinja2" :fetcher github)


### PR DESCRIPTION
[mmm-jinja2][]

I've written a `mmm-jinja2` class that adds [Jinja2][] tag support into other major modes with [mmm-mode][].

The Salt-mode depends on this package - so the salt-mode recipe shouldn't be merged until this one is. 

[mmm-jinja2]: https://github.com/beardedprojamz/mmm-jinja2/
[Jinja2]: http://jinja.pocoo.org/
[mmm-mode]: https://github.com/purcell/mmm-mode