### PR TITLE
Add c0-mode

### DIFF
--- a/recipes/c0-mode
+++ b/recipes/c0-mode
@@ -1,0 +1,1 @@
+(c0-mode :fetcher github :repo "catern/c0-mode")


### PR DESCRIPTION
C0 is a subset of C developed for pedagogical purposes at Carnegie Mellon University. It is extensively described at http://c0.typesafety.net/

Previously c0-mode was only local to CMU, and installed out of a directory in our networked filesystem, but to make it easier for students to use C0 and c0-mode off of CMU computers, we want to get it packaged in MELPA. (Preferably sooner rather than later, since the CMU semester has already started.)