### PR TITLE
Don't include python sources within anaconda-mode package.

### DIFF
--- a/recipes/anaconda-mode
+++ b/recipes/anaconda-mode
@@ -1,4 +1,1 @@
-(anaconda-mode
- :fetcher github
- :repo "proofit404/anaconda-mode"
- :files ("*.el" "*.py"))
+(anaconda-mode :fetcher github :repo "proofit404/anaconda-mode")


### PR DESCRIPTION
Anaconda mode currently install all its python side dependencies from PyPI.