### PR TITLE
Add recipe for synonymous

### DIFF
--- a/recipes/synonymous
+++ b/recipes/synonymous
@@ -1,0 +1,1 @@
+(synonymous :fetcher github :repo "toroidal-code/synonymous.el")


### PR DESCRIPTION
This commit adds a recipe for a thesaurus tool. Advantages over current synonym/thesaurus plugins are that it does not require a local thesaurus package (as synosaurus does for English) and uses a web API that provides significantly more information for word lookup and suggestions (see an example [here](http://synonymous.heroku.com/talk)).