### PR TITLE
Add fstar-mode

### DIFF
--- a/recipes/fstar-mode
+++ b/recipes/fstar-mode
@@ -1,0 +1,3 @@
+(fstar-mode
+ :fetcher github
+ :repo "FStarLang/fstar-mode.el")


### PR DESCRIPTION
F* is a functional, dependently typed programming language from MSR
(https://www.fstar-lang.org/). This is a basic editing mode for F*, with live
verification support (Flycheck) and interactive mode (like Proof-General)
support as well.

In the long run I think I'll move the Flycheck part to a separate package (or
even move the checker definition to Flycheck itself), but for now the
other verification mode (interactive) is a bit too experimental.

Cheers and thanks as always for your hard work,
Clément.