### PR TITLE
remark-mode: Add missing remark.html file

### DIFF
--- a/recipes/remark-mode
+++ b/recipes/remark-mode
@@ -1,1 +1,1 @@
-(remark-mode :fetcher github :repo "torgeir/remark-mode.el")
+(remark-mode :fetcher github :repo "torgeir/remark-mode.el" :files (:defaults "remark.html"))


### PR DESCRIPTION
Be specific about which files to include. This file is needed as it is the html skeleton for the slideshow remark-mode produces.