### PR TITLE
Add flycheck-nim recipe

### DIFF
--- a/recipes/flycheck-nim
+++ b/recipes/flycheck-nim
@@ -1,0 +1,1 @@
+(flycheck-nim :repo "ALSchwalm/flycheck-nim" :fetcher github)


### PR DESCRIPTION
`flycheck-nim.el` is a package that adds support for the [nim programming language](http://nim-lang.org/) to flycheck. It is available [here](https://github.com/ALSchwalm/flycheck-nim). I am the author and maintainer.