### PR TITLE
Update ranger package location.

### DIFF
--- a/recipes/ranger
+++ b/recipes/ranger
@@ -1,3 +1,3 @@
 (ranger :fetcher github
-          :repo "ralesi/ranger"
+          :repo "ralesi/ranger.el"
           :old-names (evil-ranger))


### PR DESCRIPTION
Based on some requests, have been asked to change repo name to designate as an elisp package, since the tool this is based on is also called just ranger.