### PR TITLE
Add recipe for ‘cyphejor’

### DIFF
--- a/recipes/cyphejor
+++ b/recipes/cyphejor
@@ -1,0 +1,1 @@
+(cyphejor :repo "mrkkrp/cyphejor" :fetcher github)


### PR DESCRIPTION
Cyphejor is a package for shortening major mode names according to user-defined rules.

Repository: https://github.com/mrkkrp/cyphejor
