### PR TITLE
update directory scheme for haskell-emacs

### DIFF
--- a/recipes/haskell-emacs
+++ b/recipes/haskell-emacs
@@ -1,3 +1,3 @@
 (haskell-emacs :fetcher github
                :repo "knupfer/haskell-emacs"
-               :files (:defaults "*.hs" (:exclude "*Test.hs")))
+               :files (:defaults "*.hs" "*.org" "Foreign"))

--- a/recipes/haskell-emacs-base
+++ b/recipes/haskell-emacs-base
@@ -1,4 +1,3 @@
 (haskell-emacs-base :fetcher github
                     :repo "knupfer/haskell-emacs"
-                    :files ("modules/base/*.el" "modules/base/*.hs"
-                            (:exclude "*-test.el" "*Test.hs")))
+                    :files ("modules/base/*.el" "modules/base/*.hs"))

--- a/recipes/haskell-emacs-text
+++ b/recipes/haskell-emacs-text
@@ -1,4 +1,3 @@
 (haskell-emacs-text :fetcher github
                     :repo "knupfer/haskell-emacs"
-                    :files ("modules/text/*.el" "modules/text/*.hs"
-                            (:exclude "*-test.el" "*Test.hs")))
+                    :files ("modules/text/*.el" "modules/text/*.hs"))


### PR DESCRIPTION
- tests are now in a seperate directory
- additional .hs files are in Foreign/
- .org file will be used for a help function