### PR TITLE
Add recipes/jabber-otr

### DIFF
--- a/recipes/jabber-otr
+++ b/recipes/jabber-otr
@@ -1,0 +1,3 @@
+(jabber-otr
+ :fetcher github :repo "legoscia/emacs-jabber-otr"
+ :files (:defaults "emacs-otr.py"))


### PR DESCRIPTION
This is an add-on for OTR encryption in jabber.el.

The upstream repository is [legoscia/emacs-jabber-otr](https://github.com/legoscia/emacs-jabber-otr/) on GitHub. I am the maintainer.