### PR TITLE
Update recipe for orgmode-mediawiki

### DIFF
--- a/recipes/ox-mediawiki
+++ b/recipes/ox-mediawiki
@@ -1,2 +1,2 @@
 (ox-mediawiki :fetcher github
-              :repo "tomalexander/orgmode-mediawiki")
+              :repo "manuel-uberti/orgmode-mediawiki")


### PR DESCRIPTION
Original author does not seem to be maintaining this package anymore. Check here for details: https://github.com/tomalexander/orgmode-mediawiki

At the moment, the package is not working without this PR: https://github.com/tomalexander/orgmode-mediawiki/pull/14