### PR TITLE
Add recipe for restart-emacs

### DIFF
--- a/recipes/restart-emacs
+++ b/recipes/restart-emacs
@@ -1,0 +1,1 @@
+(restart-emacs :fetcher github :repo "iqbalansari/restart-emacs")


### PR DESCRIPTION
This package adds a single command `resem-restart-emacs` which can be used restart emacs from within emacs. The code lives in https://github.com/iqbalansari/restart-emacs. I am the author and the maintainer.