### PR TITLE
Add recipe for julia-shell

### DIFF
--- a/recipes/julia-shell
+++ b/recipes/julia-shell
@@ -1,3 +1,3 @@
 (julia-shell :fetcher github
              :repo "dennisog/julia-shell-mode"
-             :files ("*.el" "*.jl"))
+             :files (:defaults "*.jl"))

--- a/recipes/julia-shell
+++ b/recipes/julia-shell
@@ -1,0 +1,3 @@
+(julia-shell :fetcher github
+             :repo "dennisog/julia-shell-mode"
+             :files ("*.el" "*.jl"))


### PR DESCRIPTION
This package adds better emacs integration with an interactive [Julia](http://julialang.org/) shell. [The original julia-mode](https://github.com/JuliaLang/julia/blob/master/contrib/julia-mode.el) has some shell features, but it lacks completions and other features. As of right now, I'm the sole maintainer and the code sits [here](https://github.com/dennisog/julia-shell-mode).