### PR TITLE
Add defproject recipe

### DIFF
--- a/recipes/defproject
+++ b/recipes/defproject
@@ -1,0 +1,1 @@
+(defproject :fetcher github :repo "kotfic/defproject")


### PR DESCRIPTION
[defproject](https://github.com/kotfic/defproject) lets you define dir-locals in elisp in a cleaner way using use-package like macros.

I'm a contributor with push access.

I contributed [57c0bcb](https://github.com/kotfic/defproject/commit/57c0bcb4adfa630e669dbd6f76e846465da6a149) and [5b5f6](https://github.com/kotfic/defproject/commit/5b5f6283ed72a430664bb7ca8f9382d0ac22dc21)  to make compatible with MELPA.