### PR TITLE
Add recipe for jscs

### DIFF
--- a/recipes/jscs
+++ b/recipes/jscs
@@ -1,0 +1,1 @@
+(jscs :repo "papaeye/emacs-jscs" :fetcher github)


### PR DESCRIPTION
[jscs.el](https://github.com/papaeye/emacs-jscs) is a elisp for [JSCS (JavaScript Code Style)](http://jscs.info/):

- Apply indentation rules from JSCS config file to the current buffer
- Run `jscs --fix` borrowed code from gofmt of go-mode.el

I'm a maintainer (papaeye/emacs-jscs#1).