### PR TITLE
Move hoa-pp-mode repository

### DIFF
--- a/recipes/hoa-pp-mode
+++ b/recipes/hoa-pp-mode
@@ -1,1 +1,1 @@
-(hoa-pp-mode :repo "stevenremot/hoa-pp-mode" :fetcher github)
+(hoa-pp-mode :repo "hoaproject/Contributions-Emacs-Pp" :fetcher github)


### PR DESCRIPTION
Hello,

the `hoa-pp-mode` repository has been moved under the @hoaproject github organization. This pull request update the recipe to fetch the package from its new home.