### PR TITLE
Add hcl-mode recipe

### DIFF
--- a/recipes/hcl-mode
+++ b/recipes/hcl-mode
@@ -1,0 +1,1 @@
+(hcl-mode :repo "syohex/emacs-hcl-mode" :fetcher github)


### PR DESCRIPTION
`hcl-mode` provides a major mode of [HCL](https://github.com/hashicorp/hcl/)(Hashicorp Configuration Language).

https://github.com/syohex/emacs-hcl-mode

(I'll rewrite [terraform-mode](https://github.com/syohex/emacs-terraform-mode) based on hcl-mode after registered hcl-mode)