### PR TITLE
Add recipe tab-jump-out

### DIFF
--- a/recipes/scratches
+++ b/recipes/scratches
@@ -1,0 +1,1 @@
+(scratches :repo "cheunghy/scratches" :fetcher github)

--- a/recipes/tab-jump-out
+++ b/recipes/tab-jump-out
@@ -1,0 +1,1 @@
+(tab-jump-out :repo "cheunghy/tab-jump-out" :fetcher github)


### PR DESCRIPTION
tab-jump-out is a package for jump out of parenthesis and quotes with tab.

Usage:

you can enable tab-jump-out-mode to tab out of parenthesis, or just bind tab-jump-out to tab.

When working with auto complete engine like auto-complete and company, and yasnippet, you can set yas fallback behavior to tab jump out and do not enable tab jump out mode to ensure yasnippet run first.
