### PR TITLE
Split off EmacSQL backends into separate packages.

### DIFF
--- a/recipes/emacsql
+++ b/recipes/emacsql
@@ -1,3 +1,3 @@
 (emacsql :repo "skeeto/emacsql"
          :fetcher github
-         :files ("*.el" "README.md" "sqlite"))
+         :files ("emacsql.el" "emacsql-compiler.el" "README.md"))

--- a/recipes/emacsql-mysql
+++ b/recipes/emacsql-mysql
@@ -1,0 +1,3 @@
+(emacsql-mysql :repo "skeeto/emacsql"
+               :fetcher github
+               :files ("emacsql-mysql.el"))

--- a/recipes/emacsql-psql
+++ b/recipes/emacsql-psql
@@ -1,0 +1,3 @@
+(emacsql-psql :repo "skeeto/emacsql"
+              :fetcher github
+              :files ("emacsql-psql.el" "emacsql-pg.el"))

--- a/recipes/emacsql-sqlite
+++ b/recipes/emacsql-sqlite
@@ -1,0 +1,3 @@
+(emacsql-sqlite :repo "skeeto/emacsql"
+                :fetcher github
+                :files ("emacsql-sqlite.el" "emacsql-system.el" "sqlite"))


### PR DESCRIPTION
The `emacsql` package is broken into: `emacsql`, `emacsql-sqlite`, `emacsql-psql`, and `emacsql-mysql`. PostgreSQL users don't want to be bothered with a SQLite binary and SQLite users don't want pg.el. I've already made the appropriate changes in the EmacSQL repository.

See also: skeeto/emacsql/issues/15
