### PR TITLE
Add go-playground recipe

### DIFF
--- a/recipes/go-playground
+++ b/recipes/go-playground
@@ -1,0 +1,1 @@
+(go-playground :repo "grafov/go-playground" :fetcher github)


### PR DESCRIPTION
Add new recipe with go-playground mode for Go language. Under GPLv3.