### PR TITLE
Add recipe for abyss-theme.

### DIFF
--- a/recipes/abyss-theme
+++ b/recipes/abyss-theme
@@ -1,0 +1,1 @@
+(abyss-theme :fetcher github :repo "mgrbyte/emacs-abyss-theme")


### PR DESCRIPTION
A dark theme with contrasting colours for Emacs24 based on the
[https://github.com/andre-richter/emacs-lush-theme](lush) theme, using the same colours palette
as the the built-in dichromacy theme; intended to be suitable
for red/green colour blind users.

Checks have been made using `flycheck-package` and `package-build-current-recipe`.
I am the author of the [package](https://github.com/mgrbyte/emacs-abyss-theme) being submitted.