### PR TITLE
Add org-notify

### DIFF
--- a/recipes/org-alert
+++ b/recipes/org-alert
@@ -1,0 +1,1 @@
+(org-alert :fetcher github :repo "groksteve/org-alert")

--- a/recipes/org-notify
+++ b/recipes/org-notify
@@ -1,1 +1,0 @@
-(org-notify :fetcher github :repo "groksteve/org-notify")

--- a/recipes/org-notify
+++ b/recipes/org-notify
@@ -1,0 +1,1 @@
+(org-notify :fetcher github :repo "groksteve/org-notify")


### PR DESCRIPTION
Org-notify provides system notifications via notify-send for org agenda
deadlines which are active and due.

Original repository: [org-notify](https://github.com/groksteve/org-notify)

I am the package creator and maintainer and have tested the package build with melpa's current makefile.