### PR TITLE
remove "snippets" default :files entry from haskell mode recipe

### DIFF
--- a/recipes/haskell-mode
+++ b/recipes/haskell-mode
@@ -3,5 +3,4 @@
  :fetcher github
  :files (:defaults
          "NEWS"
-         "snippets"
          "logo.svg"))


### PR DESCRIPTION
Because neither the latest commit (on default master branch) or the
latest release has the "snippets" directory anymore.

---

I think maybe it was moved to https://github.com/AndreaCrotti/yasnippet-snippets/tree/master/haskell-mode?