### PR TITLE
Recipe: git-commit-insert-issue

### DIFF
--- a/recipes/git-commit-insert-issue
+++ b/recipes/git-commit-insert-issue
@@ -1,0 +1,1 @@
+(git-commit-insert-issue :fetcher gitlab :repo "emacs-stuff/git-commit-insert-issue")


### PR DESCRIPTION
Hi !

This package is to get a helm list of (github) issues when we type "Fixes #" in a commit message.

https://gitlab.com/emacs-stuff/git-commit-insert-issue (I'm the maintainer)

The recipe compiles and I can require it afterwards, but two notes:

- the list-package doesn't show my package description. I did put it in the first line and in a `;;; Summary: ` but this doesn't seem to be enough;
-  I rely on a package that isn't on melpa ([github-issues](https://github.com/inkel/github-issues.el)), so I included the source which I load with this code:

```
(let ((load-path (cons nil load-path)))
  (load-file "github-issues.el")) ;; not in MELPA, local copy.
```
It seems ok now since I can require it, but you may want to confirm.

Regards