### PR TITLE
add recipe for cliphist

### DIFF
--- a/recipes/cliphist
+++ b/recipes/cliphist
@@ -1,0 +1,2 @@
+(cliphist :fetcher github
+                :repo "redguardtoo/cliphist")


### PR DESCRIPTION
Read clipboard history from Parcellite on Linux and Flycut on OS X.