### PR TITLE
Add editorconfig-core recipe

### DIFF
--- a/recipes/editorconfig-core
+++ b/recipes/editorconfig-core
@@ -1,0 +1,1 @@
+(editorconfig-core :repo "10sr/editorconfig-core-emacslisp" :fetcher github)


### PR DESCRIPTION
[EditorConfig](http://editorconfig.org/) core library written purely in Emacs Lisp.

I am the maintainer of this package.
URL: https://github.com/10sr/editorconfig-core-emacslisp