### PR TITLE
Add flycheck-processing

### DIFF
--- a/recipes/flycheck-processing
+++ b/recipes/flycheck-processing
@@ -1,0 +1,4 @@
+(flycheck-processing
+ :repo "ptrv/processing2-emacs"
+ :fetcher github
+ :files ("flycheck-processing.el"))


### PR DESCRIPTION
This is a Flycheck checker for the [Processing](https://processing.org/) language.

I chose to add this checker to the processing-mode package's repository https://github.com/ptrv/processing2-emacs. The functionality was added in the PR https://github.com/ptrv/processing2-emacs/pull/8, where I also had discussion about the MELPA inclusion with the maintainer @ptrv.

There is one minor PR pending that fixes a flycheck-package warning https://github.com/ptrv/processing2-emacs/pull/9.

I have tested making, installing and using the package.