### PR TITLE
Add recipe for mu4e-alert

### DIFF
--- a/recipes/mu4e-alert
+++ b/recipes/mu4e-alert
@@ -1,0 +1,1 @@
+(mu4e-alert :fetcher github :repo "iqbalansari/mu4e-alert")


### PR DESCRIPTION
This adds recipe for `mu4e-alert`. I am the author of the package. The code lives in https://github.com/iqbalansari/mu4e-alert  

The package provides desktop notifications for unread emails in `mu4e` (`mu` to be more accurate). A dependency is declared on Emacs v24.1, since the package uses lexical binding. A dependency has not been declared on `mu4e` since it is not available on MELPA.

I tried building and installing the package locally using `package-build`.

Thanks