### PR TITLE
Added django-manage-mode recipe

### DIFF
--- a/recipes/django-manage
+++ b/recipes/django-manage
@@ -1,0 +1,1 @@
+(django-manage :fetcher github :repo "gopar/django-manage")


### PR DESCRIPTION
Recipe for `django-manage-mode`. A minor mode for controlling `manage.py` which is what every django project uses.

https://github.com/gopar/django-manage-mode

I am the maintainer.

Let me know if I am missing anything, or have something out of place.