### PR TITLE
Add jbeans theme recipe

### DIFF
--- a/recipes/jbeans-theme
+++ b/recipes/jbeans-theme
@@ -1,0 +1,1 @@
+(jbeans-theme :fetcher github :repo "synic/jbeans-emacs")


### PR DESCRIPTION
JBeans is based on ujelly, which is here: https://github.com/marktran/color-theme-ujelly

I am creating a new theme instead of modifying the old theme because of a fundamental difference in whites - the default foreground color in jbeans is less blinding.

In addition, I've added support for a few more modern plugins, I've changed a few of the colors, and I've organized the file better.

Overall I think it's a bit more true to the original jellybeans VIM theme.