### PR TITLE
Added recipe for django-manage

### DIFF
--- a/recipes/django-manage
+++ b/recipes/django-manage
@@ -1,0 +1,1 @@
+(django-manage :fetcher github :repo "gopar/django-manage")


### PR DESCRIPTION
Recipe for `django-manage`. A minor mode for controlling `manage.py` which is what every django project uses.

https://github.com/gopar/django-manage

I am the maintainer.

I had a previous pr #3209 but it needed work, even renaming the file and package so I decided to close it and start a new PR. Let me know if I'm still missing anything, or have something out of place. Thanks alot fot the feedback :)