### PR TITLE
Add go-rename

### DIFF
--- a/recipes/go-rename
+++ b/recipes/go-rename
@@ -1,0 +1,4 @@
+(go-rename
+ :fetcher git
+ :url "https://go.googlesource.com/tools"
+ :files ("refactor/rename/go-rename.el"))


### PR DESCRIPTION
go-rename provides integration of the 'gorename' tool into Emacs.

Link to the package file in the official repository:
https://go.googlesource.com/tools/+/master/refactor/rename/go-rename.el

I am not the author of the package but use it quite a lot. I've also submitted
the following package.el compatibility changes for go-rename:
https://go-review.googlesource.com/#/c/15527/