### PR TITLE
Add ido-grid-mode

### DIFF
--- a/recipes/ido-grid-mode
+++ b/recipes/ido-grid-mode
@@ -1,0 +1,1 @@
+(ido-grid-mode :fetcher github :repo "larkery/ido-grid-mode.el")


### PR DESCRIPTION
ido-grid-mode is a package which displays ido prospects in the
minibuffer in a grid, a little like how zsh completions are displayed.

The package is at https://github.com/larkery/ido-grid-mode.el

I am the author and maintainer of ido-grid-mode.