### PR TITLE
Add unicode-troll-stopper

### DIFF
--- a/recipes/unicode-troll-stopper
+++ b/recipes/unicode-troll-stopper
@@ -1,0 +1,2 @@
+(unicode-troll-stopper :fetcher github
+                       :repo "camsaul/emacs-unicode-troll-stopper")


### PR DESCRIPTION
Hi,
This is a PR to add my [unicode-troll-stopper](https://github.com/camsaul/emacs-unicode-troll-stopper) package. `unicode-troll-stopper` is a simple minor mode that adds font-locking for Unicode homoglyphs like "Greek Question Mark" (`;`), which look like normal ASCII symbols but cause very frustrating syntax errors.