### PR TITLE
Add Matrix.org client and API `mclient'

### DIFF
--- a/recipes/matrix-client
+++ b/recipes/matrix-client
@@ -1,0 +1,1 @@
+(matrix-client :url "git://fort.kickass.systems/personal/rrix/pub/matrix.el" :fetcher git)


### PR DESCRIPTION
Summary: `mclient' provides a simple chat client and protocol API to the
Matrix.org decentralized RPC system. Users can chat with other users or
use Matrix as a messaging layer for their projects.

Direct Link: https://fort.kickass.systems:10082/cgit/personal/rrix/pub/matrix.el.git

Association: It's my package :)