### PR TITLE
Add helm-fuzzier

### DIFF
--- a/recipes/helm-fuzzier
+++ b/recipes/helm-fuzzier
@@ -1,0 +1,2 @@
+(helm-fuzzier :repo "EphramPerdition/helm-fuzzier"
+                 :fetcher github)


### PR DESCRIPTION
[helm-fuzzier](https://github.com/EphramPerdition/helm-fuzzier) improves Helm's fuzzy matching results. 
It works well in combination with `helm-flx`, or without it.

I am the author and maintainer of `helm-fuzzier`.