### PR TITLE
Add ox-trac: Org Mode Export for Trac WikiMedia

### DIFF
--- a/recipes/google-c-style
+++ b/recipes/google-c-style
@@ -1,3 +1,2 @@
-(google-c-style
- :url "http://google-styleguide.googlecode.com/svn/trunk/"
- :fetcher svn)
+(google-c-style :fetcher github
+                :repo "google/styleguide")

--- a/recipes/ox-trac
+++ b/recipes/ox-trac
@@ -1,0 +1,1 @@
+(ox-trac :fetcher github :repo "JalapenoGremlin/ox-trac")

--- a/recipes/protobuf-mode
+++ b/recipes/protobuf-mode
@@ -1,3 +1,3 @@
-(protobuf-mode :fetcher svn
-               :url "http://protobuf.googlecode.com/svn/trunk/editors/"
-               :files ("protobuf-mode.el"))
+(protobuf-mode :fetcher github
+               :repo "google/protobuf"
+               :files ("editors/protobuf-mode.el"))


### PR DESCRIPTION
This package (ox-trac) provides a Org mode backend capable of generating WikiFormatting for Trac.

The repository for this package is: https://github.com/JalapenoGremlin/ox-trac

I am the original author and maintainer of this project. 

I have tested (C-c C-c) building the recipe and have installed it into my packages.