### PR TITLE
Update google-c-style and protobuf repository

### DIFF
--- a/recipes/google-c-style
+++ b/recipes/google-c-style
@@ -1,3 +1,2 @@
-(google-c-style
- :url "http://google-styleguide.googlecode.com/svn/trunk/"
- :fetcher svn)
+(google-c-style :fetcher github
+                :repo "google/styleguide")

--- a/recipes/protobuf-mode
+++ b/recipes/protobuf-mode
@@ -1,3 +1,3 @@
-(protobuf-mode :fetcher svn
-               :url "http://protobuf.googlecode.com/svn/trunk/editors/"
-               :files ("protobuf-mode.el"))
+(protobuf-mode :fetcher github
+               :repo "google/protobuf"
+               :files ("editors/protobuf-mode.el"))


### PR DESCRIPTION
Hi, the development of this packages has been moved to github and [googlecode is shutting down](http://google-opensource.blogspot.pe/2015/03/farewell-to-google-code.html)