### PR TITLE
Add replace-symbol.el

### DIFF
--- a/recipes/replace-symbol
+++ b/recipes/replace-symbol
@@ -1,0 +1,1 @@
+(replace-symbol :repo "bmastenbrook/replace-symbol-el" :fetcher github)


### PR DESCRIPTION
`replace-symbol.el` is a simple pair of symbol-replacement functions I've been carrying around in my `.emacs.d` for a very long time. `replace-symbol-in-buffer` replaces a given symbol in an entire buffer; `replace-symbol-in-sexp` replaces within the following sexp.

I'm the original author; the authoritative source is in https://github.com/bmastenbrook/replace-symbol-el/. I have tested building the recipe and installing the resulting package per the instructions in the README.