### PR TITLE
Add pastelmac and termbright themes

### DIFF
--- a/recipes/pastelmac-theme
+++ b/recipes/pastelmac-theme
@@ -1,0 +1,1 @@
+(pastelmac-theme :repo "bmastenbrook/pastelmac-theme-el" :fetcher github)

--- a/recipes/termbright-theme
+++ b/recipes/termbright-theme
@@ -1,0 +1,1 @@
+(termbright-theme :repo "bmastenbrook/termbright-theme-el" :fetcher github)


### PR DESCRIPTION
A pair of themes, one for use with window systems and the other for use on plain terminals. See https://github.com/bmastenbrook/pastelmac-theme-el and https://github.com/bmastenbrook/termbright-theme-el for screenshots.