### PR TITLE
Update recipe cal-china-x to point to github.

### DIFF
--- a/recipes/cal-china-x
+++ b/recipes/cal-china-x
@@ -1,1 +1,1 @@
-(cal-china-x :fetcher wiki)
+(cal-china-x :repo "xwl/cal-china-x" :fetcher github)


### PR DESCRIPTION
i'm author of cal-china-x.el.  This package has been moved to github for long.  And the current version in melpla(which points to emacswiki) is pretty outdated. 