### PR TITLE
Add live-py-mode plugin

### DIFF
--- a/recipes/live-py-mode
+++ b/recipes/live-py-mode
@@ -1,0 +1,4 @@
+(live-py-mode
+ :fetcher github
+ :repo "donkirkby/live-py-plugin"
+ :files ("emacs-live-py-mode/live-py-mode.el" "plugin/PySrc/*.py"))


### PR DESCRIPTION
This adds the python live coding plugin for emacs developed by @donkirkby.

I've already discussed with @donkirkby in https://github.com/donkirkby/live-py-plugin/issues/50 which this PR should close.