### PR TITLE
fix(run-travis-ci): only attempt to build modified recipes if they exist

### DIFF
--- a/run-travis-ci.sh
+++ b/run-travis-ci.sh
@@ -18,9 +18,11 @@ if [ -n "$TRAVIS_COMMIT_RANGE" ]; then
     echo "Building recipes touched in commits $TRAVIS_COMMIT_RANGE"
     changed_recipes=$(git show --pretty=format: --name-only "$TRAVIS_COMMIT_RANGE" |grep -e '^recipes/'|sed 's/^recipes\///'|uniq)
     for recipe_name in $changed_recipes; do
-        echo "----------------------------------------------------"
-        echo "Building new/modified recipe: $recipe_name"
-        "$ECUKES_EMACS" --batch --eval "(progn (load-file \"package-build.el\")(package-build-archive '$recipe_name))"
+        if [ -f "./recipes/$recipe_name" ]; then
+            echo "----------------------------------------------------"
+            echo "Building new/modified recipe: $recipe_name"
+            "$ECUKES_EMACS" --batch --eval "(progn (load-file \"package-build.el\")(package-build-archive '$recipe_name))"
+        fi
     done
 fi
 


### PR DESCRIPTION
i.e. They were not deleted.

Ref #3263 to see an example of the travis build failing due to this.

---

(Assuming the loop always stays in the same directory after building each recipe?)