### PR TITLE
Adding noxml-fold recipe.

### DIFF
--- a/recipes/noxml-fold
+++ b/recipes/noxml-fold
@@ -1,0 +1,1 @@
+(noxml-fold :fetcher github :repo "paddymcall/noXML-fold")


### PR DESCRIPTION
* A brief summary of what the package does.

noXML-fold folds away markup in xml files (tags or whole elements),
similar to what tex-fold-mode does for (La)TeX files.

* A direct link to the package repository

https://github.com/paddymcall/noXML-fold

* Your association with the package

I wrote and maintain this package.