### PR TITLE
remove magit-tramp

### DIFF
--- a/recipes/magit-tramp
+++ b/recipes/magit-tramp
@@ -1,1 +1,0 @@
-(magit-tramp :fetcher github :repo "magit/magit-tramp")


### PR DESCRIPTION
This package broke a long time ago and nobody every complained about
that.  Also Yann who wrote this package never replied to my inquiries.

The repository is now at https://github.com/emacsattic/magit-tramp.