### PR TITLE
Update pacmacs recipe

### DIFF
--- a/recipes/pacmacs
+++ b/recipes/pacmacs
@@ -1,5 +1,5 @@
 (pacmacs :fetcher github
-         :repo "rexim/pacmacs.el"
+         :repo "codingteam/pacmacs.el"
          :files (:defaults
                  "maps"
                  ("sprites" "sprites/*.json")


### PR DESCRIPTION
Recently, we changed the owner of the repo. Even though GitHub does pretty good job at redirecting stuff after renaming and transferring, it's always better to keep the recipe updated.