### PR TITLE
add emacs-jp/replace-colorthemes

### DIFF
--- a/recipes/color-theme-modern
+++ b/recipes/color-theme-modern
@@ -1,0 +1,3 @@
+(color-theme-modern
+ :repo "emacs-jp/replace-colorthemes"
+ :fetcher github)


### PR DESCRIPTION
Upstream is OK with it being added: https://github.com/emacs-jp/replace-colorthemes/issues/10