### PR TITLE
Add recipe for evil-indent-plus

### DIFF
--- a/recipes/evil-indent-plus
+++ b/recipes/evil-indent-plus
@@ -1,0 +1,1 @@
+(evil-indent-plus :fetcher github :repo "TheBB/evil-indent-plus")


### PR DESCRIPTION
This is a rebranded fork of `evil-indent-textobject`. That package has some serious problems which will probably never be fixed: https://github.com/cofi/evil-indent-textobject/issues/1. @cofi, who maintains that package, has no activity in the last year.

In Spacemacs we switched to using this fork, see https://github.com/syl20bnr/spacemacs/issues/2326 and https://github.com/syl20bnr/spacemacs/pull/2656.

Since we are trying to avoid using too many quelpa packages, it would be good to have this on MELPA or bundle it with Spacemacs. From the above issues, the general consensus is that this fixes a genuine problem that many people experience with the original package, so my first choice would be to have it in MELPA, so that non-Spacemacsers can benefit from it, too. I hope the name change and the extra features and bug fixes sufficiently distances this from the "fork" label.

Upstream: https://github.com/TheBB/evil-indent-plus