### PR TITLE
add recipe for elog

### DIFF
--- a/recipes/elog
+++ b/recipes/elog
@@ -1,0 +1,1 @@
+(elog :fetcher github :repo "lujun9972/elog")


### PR DESCRIPTION
elog is a simple logging library for elisp. It is extended from logito.