### PR TITLE
Add fortune-cookie

### DIFF
--- a/recipes/fortune-cookie
+++ b/recipes/fortune-cookie
@@ -1,0 +1,2 @@
+(fortune-cookie :repo "andschwa/fortune-cookie" :fetcher github)
+


### PR DESCRIPTION
A simple package which sets the `initial-scratch-message` to an output
from `fortune`, mimicking a shell login fortune. Also utilizes `cowsay`
if available, and is customizable.

https://github.com/andschwa/fortune-cookie

I am the author of this silly package.