### PR TITLE
Add jumplist recipe

### DIFF
--- a/recipes/jumplist
+++ b/recipes/jumplist
@@ -1,0 +1,1 @@
+(jumplist :repo "ganmacs/jumplist" :fetcher github)


### PR DESCRIPTION
Hello!
This patch add [jumplist](https://github.com/ganmacs/jumplist)  recipe.
This package is different from  [evil-jumper](https://github.com/bling/evil-jumper/blob/master/evil-jumper.el).
Because the evil-jumper depend on `eval-mode`, but this package does not.

Thank you.