### PR TITLE
FIX: Exclude compile-shim.el; MOD: Formatting

### DIFF
--- a/recipes/rtags
+++ b/recipes/rtags
@@ -1,1 +1,4 @@
-(rtags :fetcher github :repo "Andersbakken/rtags" :files ("src/*.el"))
+(rtags :repo "Andersbakken/rtags"
+       :fetcher github
+       :files ("src/*.el"
+               (:exclude "src/compile-shim.el")))


### PR DESCRIPTION
We recently added a compile-shim elisp file, for byte-compiling the elisp files in the make process, that's all it used for. Also I formatted the recipe a bit nicer.

Thanks,
Christian