### PR TITLE
Add recipes/sproto-mode

### DIFF
--- a/recipes/sproto-mode
+++ b/recipes/sproto-mode
@@ -1,0 +1,1 @@
+(sproto-mode :repo "m2q1n9/sproto-mode" :fetcher github)


### PR DESCRIPTION
[sproto](https://github.com/cloudwu/sproto) is another protocol library like google protocol buffers , but simple and fast. I write a sproto major mode to support syntax highlight.

https://github.com/m2q1n9/sproto-mode
