### PR TITLE
Add bind-map

### DIFF
--- a/recipes/bind-map
+++ b/recipes/bind-map
@@ -1,0 +1,1 @@
+(bind-map :repo "justbur/emacs-bind-map" :fetcher github)


### PR DESCRIPTION
bind-map is a macro that generalizes the leader concept from vim for
emacs users. It is a simple way to bind a keymap to multiple prefixes
with the option to condition on the current major mode, minor mode, or
evil state. It should be an easy way to organize key bindings in
personal keymaps.

Repo at [emacs-bind-map](https://github.com/justbur/emacs-bind-map). I'm the author