### PR TITLE
Include all .exe and .exe.config files

### DIFF
--- a/recipes/fsharp-mode
+++ b/recipes/fsharp-mode
@@ -3,5 +3,6 @@
  :repo "rneatherway/emacs-fsharp-mode-bin"
  :files ("*.el"
          ("bin"
-          "fsautocomplete.exe"
+          "*.exe"
+          "*.exe.config"
           "*.dll")))


### PR DESCRIPTION
There may soon be another .exe file from FSharp.Compiler.Service, and
fsautocomplete.exe.config has not been picked up by the current recipe,
which is affecting Windows installations.