### PR TITLE
add sibilant-mode recipe to melpa

### DIFF
--- a/recipes/sibilant-mode
+++ b/recipes/sibilant-mode
@@ -1,0 +1,2 @@
+(sibilant-mode :repo "jbr/sibilant-mode" :fetcher github)
+


### PR DESCRIPTION
This is my first melpa package, but I was able to `make recipes/sibilant-mode` and `EMACS=$(which emacs) make sandbox` and install the package successfully.  Please let me know if anything looks incorrect.

Thanks!