### PR TITLE
Add recipe for hoa-mode

### DIFF
--- a/recipes/hoa-mode
+++ b/recipes/hoa-mode
@@ -1,0 +1,2 @@
+(hoa-mode :url "https://gitlab.lrde.epita.fr/spot/emacs-modes.git"
+	  :files ("hoa-mode.el") :fetcher git)


### PR DESCRIPTION
This is a major mode for editing files in the [Hanoi Omega Automaton](http://adl.github.io/hoaf/) format.

Sources at https://gitlab.lrde.epita.fr/spot/emacs-modes/blob/master/hoa-mode.el
I'm the author.