### PR TITLE
Remove go-play recipe

### DIFF
--- a/recipes/go-play
+++ b/recipes/go-play
@@ -1,1 +1,0 @@
-(go-play :fetcher github :repo "dominikh/go-play.el")


### PR DESCRIPTION
go-play was integrated into go-mode. `go-play-buffer` and `go-play-region` are implemented in go-mode.el now.

- https://github.com/dominikh/go-play.el