### PR TITLE
Add yaml-tomato

### DIFF
--- a/recipes/yaml-tomato
+++ b/recipes/yaml-tomato
@@ -1,0 +1,1 @@
+(yaml-tomato :repo "RadekMolenda/yaml-tomato" :fetcher github)


### PR DESCRIPTION
Yaml-tomato is a simple tool to copy or show the yaml path currently under cursor.

Github: https://github.com/RadekMolenda/yaml-tomato

I am the owner of the package. And this is an initial release