### PR TITLE
add extempore-mode recipe

### DIFF
--- a/recipes/extempore-mode
+++ b/recipes/extempore-mode
@@ -1,0 +1,1 @@
+(extempore-mode :fetcher github :repo "extemporelang/extempore-emacs-mode")


### PR DESCRIPTION
This package provides functionality relating to the [Extempore programming environment](http://extemporelang.github.io). This functionality includes:

- Starting Extempore processes
- Connecting buffers to Extempore processes via tcp
- Sending to and receiving from the Extempore process
- Syntax highlighting for both scheme and xtlang (Extempore's languages)

Extempore-mode github repository is [here](https://github.com/extemporelang/extempore-emacs-mode).

I help in maintaining the package, primary maintainer is @benswift who is aware and supportive of this pull request.

We appear to have no flycheck errors, and the package builds and installs.
