### PR TITLE
applescript-mode: use official source

### DIFF
--- a/recipes/applescript-mode
+++ b/recipes/applescript-mode
@@ -1,1 +1,3 @@
-(applescript-mode :fetcher github :repo "ieure/applescript-mode")
+(applescript-mode
+ :fetcher svn
+ :url "http://svn.osdn.jp/svnroot/macemacsjp/applescript-mode/trunk")


### PR DESCRIPTION
The MacEmacs JP repository is up-to-date with the mirror currently in
use: https://osdn.jp/projects/macemacsjp/scm/svn/commits/580