### PR TITLE
Update js-comint recipe with github repo

### DIFF
--- a/recipes/js-comint
+++ b/recipes/js-comint
@@ -1,3 +1,3 @@
 (js-comint
- :url "https://svn.code.sf.net/p/js-comint-el/code/trunk"
- :fetcher svn)
+ :repo "redguardtoo/js-comint"
+ :fetcher github)


### PR DESCRIPTION
The original js-comint on sourceforge has not seen updates in 5 years.

@redguardtoo maintains a github repo with up-to-date js-comint, to which I have just contributed a [PR to add nvm support](https://github.com/redguardtoo/js-comint/pull/4).

The package builds and installs OK as specified in the recipe contributions instructions of MELPA, I hope you can make it available.

Thanks.