### PR TITLE
Add org-tracktable recipe

### DIFF
--- a/recipes/org-tracktable
+++ b/recipes/org-tracktable
@@ -1,0 +1,1 @@
+(org-tracktable :fetcher github :repo "tty-tourist/org-tracktable")


### PR DESCRIPTION
[org-tracktable](https://github.com/tty-tourist/org-tracktable) is a package for tracking your writing progress in an org-table. It provides functions for inserting a table for tracking progress, updating that table, and getting status messages with your progress.