### PR TITLE
Add java-imports

### DIFF
--- a/recipes/java-imports
+++ b/recipes/java-imports
@@ -1,0 +1,3 @@
+(java-imports
+ :fetcher github
+ :repo "dakrone/emacs-java-imports")


### PR DESCRIPTION
This is utility functions for adding `import` statements for Java. It
includes persistent caching of the packages for a class name so they
don't have to be re-entered every time.