### PR TITLE
change simple-call-tree's upstream

### DIFF
--- a/recipes/simple-call-tree
+++ b/recipes/simple-call-tree
@@ -1,1 +1,3 @@
-(simple-call-tree :fetcher wiki)
+(simple-call-tree :fetcher github
+                  :repo "vapniks/simple-call-tree"
+                  :old-names (simple-call-tree+))

--- a/recipes/simple-call-tree+
+++ b/recipes/simple-call-tree+
@@ -1,1 +1,0 @@
-(simple-call-tree+ :fetcher wiki)


### PR DESCRIPTION
`simple-call-tree+` has been merged into `simple-call-tree`
and is now maintained on Github.

See https://github.com/vapniks/simple-call-tree/issues/3.