### PR TITLE
remove unmaintained starter-kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,27 +283,35 @@ and `:fetcher` specified,
 
 ### Example: Multiple Packages in one Repository
 
-The
-[emacs-starter-kit](https://github.com/technomancy/emacs-starter-kit)
-contains the *starter-kit* package along with extra packages in the
-`modules` directory; *starter-kit-bindings*, *starter-kit-lisp*, etc.
+The [projectile](https://github.com/bbatsov/projectile) repository
+contains three libraries `projectile.el`, `helm-projectile.el`, and
+`persp-projectile.el`.  The latter two libraries are optional and
+users who don't want to use the packages `helm` and/or `perspective`
+should not be forced to install them just so they can install
+`projectile`.  These libraries should therefore be distributed as
+separate packages.
+
+The three packages have to be declared in three separate files
+`recipes/projectile`, `recipes/helm-projectile`, and
+`recipes/persp-projectile`:
 
 ```lisp
-(starter-kit
- :url "https://github.com/technomancy/emacs-starter-kit.git"
- :fetcher git)
-(starter-kit-bindings
- :url "https://github.com/technomancy/emacs-starter-kit.git"
- :fetcher git
- :files ("modules/starter-kit-bindings.el"))
+(projectile :repo "bbatsov/projectile"
+            :fetcher github
+            :files ("projectile.el"))
 ```
 
-Notice that `:files` is not specified for `starter-kit` since
-package-build will automatically add all `.el` files in the root
-directory of the repository.  The `starter-kit-bindings` repository is
-contained in the `modules/` subdirectory and thus needs the packages
-files specified explicitly.
+```lisp
+(helm-projectile :repo "bbatsov/projectile"
+                 :fetcher github
+                 :files ("helm-projectile.el"))
+```
 
+```lisp
+(persp-projectile :repo "bbatsov/projectile"
+                  :fetcher github
+                  :files ("persp-projectile.el"))
+```
 
 ### Example: Multiple Files in Multiple Directories
 

--- a/recipes/starter-kit
+++ b/recipes/starter-kit
@@ -1,2 +1,0 @@
-(starter-kit :repo "technomancy/emacs-starter-kit" :fetcher github
-             :branch "v2")

--- a/recipes/starter-kit-bindings
+++ b/recipes/starter-kit-bindings
@@ -1,4 +1,0 @@
-(starter-kit-bindings :repo "technomancy/emacs-starter-kit"
-                      :fetcher github
-                      :branch "v2"
-                      :files ("modules/starter-kit-bindings.el"))

--- a/recipes/starter-kit-eshell
+++ b/recipes/starter-kit-eshell
@@ -1,4 +1,0 @@
-(starter-kit-eshell :repo "technomancy/emacs-starter-kit"
-                    :fetcher github
-                    :branch "v2"
-                    :files ("modules/starter-kit-eshell.el"))

--- a/recipes/starter-kit-js
+++ b/recipes/starter-kit-js
@@ -1,4 +1,0 @@
-(starter-kit-js :repo "technomancy/emacs-starter-kit"
-                :fetcher github
-                :branch "v2"
-                :files ("modules/starter-kit-js.el"))

--- a/recipes/starter-kit-lisp
+++ b/recipes/starter-kit-lisp
@@ -1,4 +1,0 @@
-(starter-kit-lisp :repo "technomancy/emacs-starter-kit"
-                  :fetcher github
-                  :branch "v2"
-                  :files ("modules/starter-kit-lisp.el"))

--- a/recipes/starter-kit-perl
+++ b/recipes/starter-kit-perl
@@ -1,4 +1,0 @@
-(starter-kit-perl :repo "technomancy/emacs-starter-kit"
-                  :fetcher github
-                  :branch "v2"
-                  :files ("modules/starter-kit-perl.el"))

--- a/recipes/starter-kit-ruby
+++ b/recipes/starter-kit-ruby
@@ -1,4 +1,0 @@
-(starter-kit-ruby :repo "technomancy/emacs-starter-kit"
-                  :fetcher github
-                  :branch "v2"
-                  :files ("modules/starter-kit-ruby.el"))


### PR DESCRIPTION
The original and very influential Starter-Kit has come to age and should
be considered unmaintained.

See https://github.com/magit/magit/issues/1923#issuecomment-116082321.

The Starter-Kit was also used as an example in the README.md, so that
also has to be replaced.  Projectile seems to be a good choice for that,
better than the Starter-Kit actually, because it is more typical.