### PR TITLE
rename angularjs-mode to angular-mode

### DIFF
--- a/recipes/angular-mode
+++ b/recipes/angular-mode
@@ -1,0 +1,5 @@
+(angular-mode
+ :fetcher github
+ :repo "omouse/angularjs-mode"
+ :files (:defaults "snippets")
+ :old-names (angularjs-mode))

--- a/recipes/angularjs-mode
+++ b/recipes/angularjs-mode
@@ -1,5 +1,0 @@
-(angularjs-mode
- :fetcher github
- :repo "omouse/angularjs-mode"
- :files (:defaults
-         "snippets"))


### PR DESCRIPTION
Because the name of the library is `angular-mode.el`, the package should be named `angular-mode` instead of `angularjs-mode`.