### PR TITLE
add github-issues recipe

### DIFF
--- a/recipes/github-issues
+++ b/recipes/github-issues
@@ -1,0 +1,1 @@
+(github-issues :fetcher github :repo "inkel/github-issues.el")


### PR DESCRIPTION
Currently `git-commit-insert-issue` bundles a copy of `github-issues` because @vindarel so far has not responded to the [request](https://github.com/inkel/github-issues.el/issues/2) for him to add his package to Melpa. So I am doing it for him.

This has been discussed before but I can not find that discussion.

I'll also open a merge request against `git-commit-insert-issue` for `github-issues.el` to be removed. That should not be merged until @purcell has merged this.