### PR TITLE
Add selectric-mode recipe

### DIFF
--- a/recipes/selectric-mode
+++ b/recipes/selectric-mode
@@ -1,0 +1,3 @@
+(selectric-mode :repo "rbanffy/selectric-mode"
+                :fetcher github
+                :files (:defaults "*.wav"))


### PR DESCRIPTION
Make your Emacs sound like a proper typewriter. Extremely useful if you
have a puny, silent, rubberish, non-clicky keyboard.

Added recipe with consent from
[author](https://github.com/rbanffy/selectric-mode/issues/3)