### PR TITLE
Get some packages from the Emacsorphanage

### DIFF
--- a/recipes/crontab-mode
+++ b/recipes/crontab-mode
@@ -1,1 +1,1 @@
-(crontab-mode :fetcher github :repo "emacsmirror/crontab-mode")
+(crontab-mode :fetcher github :repo "emacsorphanage/crontab-mode")

--- a/recipes/dedicated
+++ b/recipes/dedicated
@@ -1,1 +1,1 @@
-(dedicated :fetcher github :repo "emacsmirror/dedicated")
+(dedicated :fetcher github :repo "emacsorphanage/dedicated")

--- a/recipes/keydef
+++ b/recipes/keydef
@@ -1,3 +1,1 @@
-(keydef
- :repo "emacsmirror/keydef"
- :fetcher github)
+(keydef :fetcher github :repo "emacsorphanage/keydef")

--- a/recipes/log4j-mode
+++ b/recipes/log4j-mode
@@ -1,1 +1,1 @@
-(log4j-mode :repo "emacsmirror/log4j-mode" :fetcher github)
+(log4j-mode :fetcher github :repo "emacsorphanage/log4j-mode")

--- a/recipes/miniedit
+++ b/recipes/miniedit
@@ -1,2 +1,1 @@
-(miniedit :repo "emacsmirror/miniedit"
-          :fetcher github)
+(miniedit :fetcher github :repo "emacsorphanage/miniedit")

--- a/recipes/oberon
+++ b/recipes/oberon
@@ -1,1 +1,1 @@
-(oberon :fetcher github :repo "emacsmirror/oberon")
+(oberon :fetcher github :repo "emacsorphanage/oberon")

--- a/recipes/pager
+++ b/recipes/pager
@@ -1,1 +1,1 @@
-(pager :fetcher github :repo "emacsmirror/pager")
+(pager :fetcher github :repo "emacsorphanage/pager")

--- a/recipes/pointback
+++ b/recipes/pointback
@@ -1,1 +1,1 @@
-(pointback :fetcher github :repo "emacsmirror/pointback")
+(pointback :fetcher github :repo "emacsorphanage/pointback")

--- a/recipes/session
+++ b/recipes/session
@@ -1,1 +1,1 @@
-(session :fetcher github :repo "emacsmirror/session")
+(session :fetcher github :repo "emacsorphanage/session")

--- a/recipes/smarty-mode
+++ b/recipes/smarty-mode
@@ -1,1 +1,1 @@
-(smarty-mode :fetcher github :repo "emacsmirror/smarty-mode")
+(smarty-mode :fetcher github :repo "emacsorphanage/smarty-mode")


### PR DESCRIPTION
I have moved all packages that Melpa used to get from the Emacsmirror to the Emacsorphanage. That's the new "upstream" and Melpa should get these packages from there. The Emacsmirror also mirrors these new "upstreams". I might even cleanup some of these packages a bit.