### PR TITLE
Add cheatsheet recipe

### DIFF
--- a/recipes/cheatsheet
+++ b/recipes/cheatsheet
@@ -1,0 +1,2 @@
+(cheatsheet :repo "darksmile/cheatsheet" :fetcher github)
+


### PR DESCRIPTION
This package just lets you to create your own Emacs cheatsheet. Resulting cheatsheet contains only keys, that you've added manually.
The way I'm using it:
```
(require 'package-name)
(cheatsheet-add :group 'PackageName
                :key "Key I'd like to use"
                :description "What this key does")
;; ...
```

Repo: https://github.com/darksmile/cheatsheet
I'm the maintainer.
You can contact me via email - shirin.nikita@gmail.com

Thanks!
