### PR TITLE
Update editorconfig-core and editorconfig-fnmatch upstream

### DIFF
--- a/recipes/editorconfig-core
+++ b/recipes/editorconfig-core
@@ -1,1 +1,3 @@
-(editorconfig-core :repo "10sr/editorconfig-core-emacslisp" :fetcher github)
+(editorconfig-core :repo "editorconfig/editorconfig-emacs"
+                   :fetcher github
+                   :files ("editorconfig-core.el" "editorconfig-core-handle.el"))

--- a/recipes/editorconfig-fnmatch
+++ b/recipes/editorconfig-fnmatch
@@ -1,1 +1,3 @@
-(editorconfig-fnmatch :repo "10sr/editorconfig-fnmatch-el" :fetcher github)
+(editorconfig-fnmatch :repo "editorconfig/editorconfig-emacs"
+                      :fetcher github
+                      :files ("editorconfig-fnmatch.el"))


### PR DESCRIPTION
I'm a contributor of EditorConfig.

Now these two packages are included in official repository.
(I'll mark my repositories as deprecated later)

PS: Can you also merge #3344 if there is no problem?

http://github.com/editorconfig/editorconfig-emacs