### PR TITLE
Fetch snippets for requirejs-emacs.

### DIFF
--- a/recipes/requirejs
+++ b/recipes/requirejs
@@ -1,2 +1,2 @@
-(requirejs :fetcher github :repo "joeheyming/requirejs-emacs")
-
+(requirejs :fetcher github :repo "joeheyming/requirejs-emacs"
+                  :files (:defaults "snippets"))


### PR DESCRIPTION
Oops, I broke package install for requirejs by adding an internal snippets dir.  Silly me.

Copied magnars's angularjs-snippets recipe (Thanks @magnars for so many good lisp examples!)