### PR TITLE
add recipe for haskell-tab-indent

### DIFF
--- a/recipes/haskell-tab-indent
+++ b/recipes/haskell-tab-indent
@@ -1,0 +1,4 @@
+(haskell-tab-indent
+ :fetcher git
+ :url "https://git.spwhitton.name/haskell-tab-indent")
+


### PR DESCRIPTION
# Summary

This file provides `haskell-tab-indent-mode`, a simple Emacs indentation minor mode for Haskell projects which require tabs for indentation and do not permit spaces (except for where clauses, as a special case).  A prominent example of such a project is [git-annex][].  The user may use TAB to cycle between possible indentations.

# Repository

`git clone https://git.spwhitton.name/haskell-tab-indent` or [GitWeb](https://git.spwhitton.name/?p=haskell-tab-indent.git;a=summary).

# Association

I am the author of this package.

[git-annex]: https://git-annex.branchable.com/coding_style/