### PR TITLE
Per-recipe adjustments to version parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MELPA 
+# MELPA
 
 [![Build Status](https://travis-ci.org/milkypostman/melpa.png?branch=master)](https://travis-ci.org/milkypostman/melpa)
 
@@ -183,6 +183,7 @@ the following form (`[...]` denotes optional or conditional values),
  :fetcher [git|github|gitlab|bitbucket|bzr|hg|darcs|fossil|svn|cvs|wiki]
  [:url "<repo url>"]
  [:repo "github-gitlab-or-bitbucket-user/repo-name"]
+ [:version-regexp "<regexp>"]
  [:module "cvs-module"]
  [:files ("<file1>" ...)])
 ```
@@ -230,13 +231,19 @@ the `git`-based fetchers.
 specifies the branch of the git repo to use. This is like `:commit`, but
 it adds the "origin/" prefix automatically.
 
+- `:version-regexp` is a regular expression for extracting a
+  version-string from the repository tags.  Version-strings must be
+  parseable by Emacs' `version-to-list` , so for an unusual tag like
+  "OTP-18.1.5", we add `:version "[^0-9]*\\(.*\\)"` to strip the
+  "OTP-" prefix.
+
 - `:module`
 specifies the module of a CVS repository to check out.  Defaults to to
 `package-name`.  Only used with `:fetcher cvs`, and otherwise ignored.
 
 - `:files` optional property specifying the elisp and info files used to build the
 package. Automatically populated by matching all `.el`, `.info` and `dir` files in the
-root of the repository and the `doc` directory. Excludes all files in the root directory 
+root of the repository and the `doc` directory. Excludes all files in the root directory
 ending in `test.el` or `tests.el`. See the default value below,
 
         ("*.el" "*.el.in" "dir"
@@ -504,7 +511,7 @@ in your `package-archives` list.
              '("melpa-stable" . "https://stable.melpa.org/packages/"))
 ```
 
-An online list of available packages can be found at 
+An online list of available packages can be found at
 [https://stable.melpa.org](https://stable.melpa.org).
 
 ### Stable Version Generation
@@ -526,8 +533,3 @@ package.
   them. Any packages you already have installed from MELPA will never
   get "updated" to the stable version because of the way version
   numbering is handled.
-
-
-
-  
-

--- a/recipes/bbdb2erc
+++ b/recipes/bbdb2erc
@@ -1,2 +1,4 @@
-(bbdb2erc :repo "unhammer/bbdb2erc" :fetcher github)
-
+(bbdb2erc
+ :repo "unhammer/bbdb2erc"
+ :fetcher github
+ :version-regexp "v\\.\\(.*\\)")

--- a/recipes/company-go
+++ b/recipes/company-go
@@ -1,2 +1,3 @@
 (company-go :repo "nsf/gocode" :fetcher github
-            :files ("emacs-company/company-go.el"))
+            :files ("emacs-company/company-go.el")
+            :version-regexp "v\\.\\(.*\\)")

--- a/recipes/erlang
+++ b/recipes/erlang
@@ -1,3 +1,6 @@
 (erlang :repo "erlang/otp"
-             :fetcher github
-             :files ("lib/tools/emacs/*.el"))
+  :fetcher github
+  ;; Requiring one dot in the version-string to weed out the old
+  ;; "erl_1252" tags
+  :version-regexp "[^0-9]*\\([0-9]*\\..*\\)"
+  :files ("lib/tools/emacs/*.el"))

--- a/recipes/go-autocomplete
+++ b/recipes/go-autocomplete
@@ -1,1 +1,5 @@
-(go-autocomplete :fetcher github :repo "nsf/gocode" :files ("emacs/go-autocomplete.el"))
+(go-autocomplete
+ :fetcher github
+ :repo "nsf/gocode"
+ :files ("emacs/go-autocomplete.el")
+ :version-regexp "v\\.\\(.*\\)")

--- a/recipes/sly-company
+++ b/recipes/sly-company
@@ -1,1 +1,4 @@
-(sly-company :fetcher github :repo "capitaomorte/sly-company" )
+(sly-company
+ :fetcher github
+ :repo "capitaomorte/sly-company"
+ :version-regexp "\\(.*\\)")

--- a/recipes/wsd-mode
+++ b/recipes/wsd-mode
@@ -1,2 +1,4 @@
 (wsd-mode
- :fetcher github :repo "josteink/wsd-mode")
+ :fetcher github
+ :repo "josteink/wsd-mode"
+ :version-regexp "v\\.\\(.*\\)")

--- a/recipes/yatex
+++ b/recipes/yatex
@@ -1,1 +1,4 @@
-(yatex :fetcher hg :url "https://www.yatex.org/hgrepos/yatex/")
+(yatex
+ :fetcher hg
+ :url "https://www.yatex.org/hgrepos/yatex/"
+ :version-regexp "yatex-\\(.*\\)")

--- a/tests/version-tests.el
+++ b/tests/version-tests.el
@@ -1,0 +1,45 @@
+(require 'ert)
+
+(require 'cl-lib)
+(require 'epg)
+(require 'mail-utils)
+(require 'message)
+(require 'mm-archive)
+(require 'network-stream)
+(require 'outline)
+(require 'url-auth)
+(require 'url-cache)
+(require 'url-handlers)
+(require 'url-http)
+
+(require 'package)
+(require 'package-build)
+(package-initialize)
+
+(ert-deftest persistent-versions-stable ()
+  (let ( (package-build-stable t)
+         (package-archives '(("melpa-stable" . "https://stable.melpa.org/packages/")))
+         (package-build--recipe-alist (package-build--read-recipes-ignore-errors)))
+
+    (package-refresh-contents)
+
+    (cl-loop for recipe in (cdr package-archive-contents)
+             do
+             (setq recipe (car recipe))
+             (should (equal
+                      (version-to-list (cadr (package-build-archive recipe)))
+                      (package-desc-version (cadr (assoc recipe package-archive-contents))))))))
+
+(ert-deftest persistent-versions ()
+  (let ( (package-build-stable nil)
+         (package-archives '(("melpa" . "https://melpa.org/packages/")))
+         (package-build--recipe-alist (package-build--read-recipes-ignore-errors)))
+
+    (package-refresh-contents)
+
+    (cl-loop for recipe in (cdr package-archive-contents)
+             do
+             (setq recipe (car recipe))
+             (should (equal
+                      (version-to-list (cadr (package-build-archive recipe)))
+                      (package-desc-version (cadr (assoc recipe package-archive-contents))))))))


### PR DESCRIPTION
This adds a new optional `:version-regexp` key to recipes; it's a regular expression where the capture group is the string you want sent to `version-to-list`.  I added one to the Erlang recipe as an example.