### PR TITLE
org-babel support for restclient.el

### DIFF
--- a/recipes/ob-restclient
+++ b/recipes/ob-restclient
@@ -1,0 +1,3 @@
+(ob-restclient :repo "alf/ob-restclient.el"
+               :fetcher github
+               :files ("ob-restclient.el"))


### PR DESCRIPTION
Since restclient.el does not currently support org-mode and org-babel, I've written this extension. It's a trivial thing, but it's useful for those who need it.