### PR TITLE
Add drawille

### DIFF
--- a/recipes/drawille.el
+++ b/recipes/drawille.el
@@ -1,3 +1,1 @@
-(drawille
- :fetcher github
- :repo "sshbio/elisp-drawille")
+(drawille :repo "sshbio/drawille" :fetcher github)

--- a/recipes/drawille.el
+++ b/recipes/drawille.el
@@ -1,0 +1,3 @@
+(drawille
+ :fetcher github
+ :repo "sshbio/elsip-drawille")

--- a/recipes/drawille.el
+++ b/recipes/drawille.el
@@ -1,3 +1,3 @@
 (drawille
  :fetcher github
- :repo "sshbio/elsip-drawille")
+ :repo "sshbio/elisp-drawille")


### PR DESCRIPTION
Emacs lisp version of [drawille](https://github.com/asciimoo/drawille) library, which permit to display graphics using braille characters.

My version can convert matrices or strings to drawille representations:
```
######                                              
#     # #####    ##   #    # # #      #      ###### 
#     # #    #  #  #  #    # # #      #      #      
#     # #    # #    # #    # # #      #      #####  
#     # #####  ###### # ## # # #      #      #      
#     # #   #  #    # ##  ## # #      #      #      
######  #    # #    # #    # # ###### ###### ###### 
```

`M-x drawille-buffer RET`

```
⡏⠉⠉⡆⡖⠒⢢⢀⠔⠢⡀⡆⠀⢰⢰⢰⠀⠀⠀⡆⠀⠀⢰⣒⣒⠂
⠧⠤⠤⠃⠏⠉⠣⠸⠉⠉⠇⠗⠉⠺⠸⠸⠤⠤⠄⠧⠤⠤⠸⠤⠤⠄
```