### PR TITLE
Add recipe for Yasnippet package without snippets

### DIFF
--- a/recipes/yasnippet-bare
+++ b/recipes/yasnippet-bare
@@ -1,0 +1,3 @@
+(yasnippet-bare :repo "capitaomorte/yasnippet"
+                :fetcher github
+                :files ("yasnippet.el"))


### PR DESCRIPTION
Yasnippet is currently the slowest package to download and install because of the whole bunch of snippets, only small part of which is actually used by any particular user. Let's increase speed and modularity by providing lightweight Yasnippet variant without built-in snippets. This way users can install `yasnippet-bare` package and then add packages providing snippets of interest on top of that.
