### PR TITLE
Add org-themis recipe to melpa

### DIFF
--- a/recipes/org-themis
+++ b/recipes/org-themis
@@ -1,0 +1,2 @@
+(org-themis :fetcher github
+            :repo "zellio/org-themis")


### PR DESCRIPTION
`org-themis` extends `org-mode` to handle multiple journal files to facilitate grouping tasks and notes under a package heading. It provides the `org-themis-minor-mode` which allows for creation, management, and manipulations of "projects". Projects in this context are a collection of files and directories.

The package can be found at https://github.com/zellio/org-themis

I am the author and maintainer of this package.