### PR TITLE
add bitbucket fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ the following form (`[...]` denotes optional or conditional values),
 
 ```lisp
 (<package-name>
- :fetcher [git|github|gitlab|bzr|hg|darcs|fossil|svn|cvs|wiki]
+ :fetcher [git|github|gitlab|bitbucket|bzr|hg|darcs|fossil|svn|cvs|wiki]
  [:url "<repo url>"]
- [:repo "github-or-gitlab-user/repo-name"]
+ [:repo "github-gitlab-or-bitbucket-user/repo-name"]
  [:module "cvs-module"]
  [:files ("<file1>" ...)])
 ```
@@ -190,12 +190,13 @@ the following form (`[...]` denotes optional or conditional values),
 - `package-name`
 a lisp symbol that has the same name as the package being specified.
 
-- `:fetcher` (one of `git, github, gitlab, bzr, hg, darcs, fossil, svn, cvs, wiki`)
-specifies the type of repository that `:url` points to. Right now
-package-build supports [git][git], [github][github], [gitlab][gitlab],
-[bazaar (bzr)][bzr], [mercurial (hg)][hg], [subversion (svn)][svn],
-[cvs][cvs], [darcs][darcs], [fossil][fossil], and [Emacs Wiki (wiki)][emacswiki] as
-possible mechanisms for checking out the repository.
+- `:fetcher` (one of `git, github, gitlab, bitbucket, bzr, hg, darcs, fossil,
+svn, cvs, wiki`) specifies the type of repository that `:url` points to. Right
+now package-build supports [git][git], [github][github], [gitlab][gitlab],
+[bitbucket][bitbucket], [bazaar (bzr)][bzr], [mercurial (hg)][hg],
+[subversion (svn)][svn], [cvs][cvs], [darcs][darcs], [fossil][fossil], and
+[Emacs Wiki (wiki)][emacswiki] as possible mechanisms for checking out the
+repository.
 
     *package-build* uses
 the corresponding application to update files before building the
@@ -213,8 +214,8 @@ differs from the package name being built.
 specifies the URL of the version control repository. *required for
 the `git`, `bzr`, `hg`, `darcs`, `fossil`, `svn` and `cvs` fetchers.*
 
-- `:repo` specifies the github/gitlab repository and is of the form
-`user/repo-name`. *required for the `github` and `gitlab` fetchers*.
+- `:repo` specifies the github/gitlab/bitbucket repository and is of the form
+`user/repo-name`. *required for the `github`, `gitlab`, and `bitbucket` fetchers*.
 
 - `:commit`
 specifies the commit of the git repo to checkout. The value
@@ -257,6 +258,7 @@ causes the default value shown above to be prepended to the specified file list.
 [git]: http://git-scm.com/
 [github]: https://github.com/
 [gitlab]: https://gitlab.com/
+[bitbucket]: https://bitbucket.org/
 [bzr]: http://bazaar.canonical.com/en/
 [hg]: https://www.mercurial-scm.org/
 [svn]: http://subversion.apache.org/

--- a/html/js/melpa.js
+++ b/html/js/melpa.js
@@ -115,6 +115,9 @@
       } else if (recipe.fetcher == "gitlab") {
         return "https://gitlab.com/" + recipe.repo +
           (recipe.branch ? "/tree/" + recipe.branch : "");
+      } else if (recipe.fetcher == "bitbucket") {
+        return "https://bitbucket.com/" + recipe.repo +
+          (recipe.branch ? "/branch/" + recipe.branch : "");
       } else if (recipe.fetcher == "wiki") {
         return "http://www.emacswiki.org/emacs/" + name + ".el";
       } else if (recipe.url) {

--- a/package-build.el
+++ b/package-build.el
@@ -534,6 +534,11 @@ Return a cons cell whose `car' is the root and whose `cdr' is the repository."
   (let* ((url (format "https://gitlab.com/%s.git" (plist-get config :repo))))
     (package-build--checkout-git name (plist-put (copy-sequence config) :url url) dir)))
 
+(defun package-build--checkout-bitbucket (name config dir)
+  "Check package NAME with config CONFIG out of bitbucket into DIR."
+  (let* ((url (format "https://bitbucket.com/%s" (plist-get config :repo))))
+    (package-build--checkout-hg name (plist-put (copy-sequence config) :url url) dir)))
+
 (defun package-build--bzr-expand-repo (repo)
   "Get REPO expanded name."
   (package-build--run-process-match "\\(?:branch root\\|repository branch\\): \\(.*\\)" nil "bzr" "info" repo))
@@ -856,7 +861,7 @@ to build the recipe."
           (cl-assert (memq thing all-keys) nil "Unknown keyword %S" thing)))
       (let ((fetcher (plist-get rest :fetcher)))
         (cl-assert fetcher nil ":fetcher is missing")
-        (when (memq fetcher '(github gitlab))
+        (when (memq fetcher '(github gitlab bitbucket))
           (cl-assert (plist-get rest :repo) ":repo is missing")))
       (dolist (key symbol-keys)
         (let ((val (plist-get rest key)))
@@ -1244,7 +1249,7 @@ Returns the archive entry for the package."
   (interactive
    (list (intern (read-string "Package name: "))
          (intern
-          (let ((fetcher-types (mapcar #'symbol-name '(github gitlab git wiki bzr hg cvs svn))))
+          (let ((fetcher-types (mapcar #'symbol-name '(github gitlab bitbucket git wiki bzr hg cvs svn))))
             (completing-read
              "Fetcher: "
              fetcher-types

--- a/recipes/2048-game
+++ b/recipes/2048-game
@@ -1,1 +1,1 @@
-(2048-game :fetcher hg :url "https://bitbucket.org/zck/2048.el")
+(2048-game :fetcher bitbucket :repo "zck/2048.el")

--- a/recipes/achievements
+++ b/recipes/achievements
@@ -1,1 +1,1 @@
-(achievements :fetcher hg :url "https://bitbucket.org/gvol/emacs-achievements")
+(achievements :fetcher bitbucket :repo "gvol/emacs-achievements")

--- a/recipes/ahg
+++ b/recipes/ahg
@@ -1,1 +1,1 @@
-(ahg :fetcher hg :url "https://bitbucket.org/agriggio/ahg")
+(ahg :fetcher bitbucket :repo "agriggio/ahg")

--- a/recipes/axiom-environment
+++ b/recipes/axiom-environment
@@ -1,4 +1,4 @@
-(axiom-environment :fetcher hg
-                   :url "https://bitbucket.org/pdo/axiom-environment"
+(axiom-environment :fetcher bitbucket
+                   :repo "pdo/axiom-environment"
                    :files ("*.el" ("data" "data/*.el") ("themes" "themes/*.el")
                            (:exclude "axiom.el" "ob-axiom.el")))

--- a/recipes/ctags
+++ b/recipes/ctags
@@ -1,1 +1,1 @@
-(ctags :fetcher hg :url "https://bitbucket.org/semente/ctags.el")
+(ctags :fetcher bitbucket :repo "semente/ctags.el")

--- a/recipes/dyalog-mode
+++ b/recipes/dyalog-mode
@@ -1,4 +1,4 @@
 (dyalog-mode
- :fetcher hg
- :url "https://bitbucket.org/harsman/dyalog-mode/"
+ :fetcher bitbucket
+ :repo "harsman/dyalog-mode"
  :files (:defaults "Emacs.apl"))

--- a/recipes/evil
+++ b/recipes/evil
@@ -1,1 +1,1 @@
-(evil :url "https://bitbucket.org/lyro/evil" :fetcher hg)
+(evil :repo "lyro/evil" :fetcher bitbucket)

--- a/recipes/figlet
+++ b/recipes/figlet
@@ -1,3 +1,3 @@
 (figlet
- :fetcher hg
- :url "https://bitbucket.org/jpkotta/figlet")
+ :fetcher bitbucket
+ :repo "jpkotta/figlet")

--- a/recipes/flex-isearch
+++ b/recipes/flex-isearch
@@ -1,3 +1,3 @@
 (flex-isearch
- :fetcher hg
- :url "https://bitbucket.org/jpkotta/flex-isearch")
+ :fetcher bitbucket
+ :repo "jpkotta/flex-isearch")

--- a/recipes/gap-mode
+++ b/recipes/gap-mode
@@ -1,4 +1,4 @@
 (gap-mode
- :fetcher hg
- :url "https://bitbucket.org/gvol/gap-mode"
+ :fetcher bitbucket
+ :repo "gvol/gap-mode"
  :files ("*.el" "emacs.gaprc"))

--- a/recipes/grass-mode
+++ b/recipes/grass-mode
@@ -1,1 +1,1 @@
-(grass-mode :fetcher hg :url "https://bitbucket.org/tws/grass-mode.el")
+(grass-mode :fetcher bitbucket :repo "tws/grass-mode.el")

--- a/recipes/grin
+++ b/recipes/grin
@@ -1,1 +1,1 @@
-(grin :fetcher hg :url "https://bitbucket.org/dariusp686/emacs-grin")
+(grin :fetcher bitbucket :repo "dariusp686/emacs-grin")

--- a/recipes/haxe-mode
+++ b/recipes/haxe-mode
@@ -1,1 +1,1 @@
-(haxe-mode :fetcher hg :url "https://bitbucket.org/jpsecher/haxe-mode")
+(haxe-mode :fetcher bitbucket :repo "jpsecher/haxe-mode")

--- a/recipes/instapaper
+++ b/recipes/instapaper
@@ -1,3 +1,3 @@
 (instapaper
- :fetcher hg
- :url "https://bitbucket.org/jfm/emacs-instapaper")
+ :fetcher bitbucket
+ :repo "jfm/emacs-instapaper")

--- a/recipes/kanban
+++ b/recipes/kanban
@@ -1,1 +1,1 @@
-(kanban :fetcher hg :url "https://bitbucket.org/ArneBab/kanban.el")
+(kanban :fetcher bitbucket :repo "ArneBab/kanban.el")

--- a/recipes/latex-pretty-symbols
+++ b/recipes/latex-pretty-symbols
@@ -1,3 +1,3 @@
 (latex-pretty-symbols
- :url "https://bitbucket.org/mortiferus/latex-pretty-symbols.el"
- :fetcher hg)
+ :repo "mortiferus/latex-pretty-symbols.el"
+ :fetcher bitbucket)

--- a/recipes/minesweeper
+++ b/recipes/minesweeper
@@ -1,1 +1,1 @@
-(minesweeper :fetcher hg :url "https://bitbucket.org/zck/minesweeper.el")
+(minesweeper :fetcher bitbucket :repo "zck/minesweeper.el")

--- a/recipes/mmm-mako
+++ b/recipes/mmm-mako
@@ -1,3 +1,3 @@
 (mmm-mako
- :url "https://bitbucket.org/pjenvey/mmm-mako"
- :fetcher hg)
+ :repo "pjenvey/mmm-mako"
+ :fetcher bitbucket)

--- a/recipes/multi-project
+++ b/recipes/multi-project
@@ -1,1 +1,1 @@
-(multi-project :fetcher hg :url "https://bitbucket.org/ellisvelo/multi-project")
+(multi-project :fetcher bitbucket :repo "ellisvelo/multi-project")

--- a/recipes/nanowrimo
+++ b/recipes/nanowrimo
@@ -1,1 +1,1 @@
-(nanowrimo :fetcher hg :url "https://bitbucket.org/gvol/nanowrimo.el")
+(nanowrimo :fetcher bitbucket :repo "gvol/nanowrimo.el")

--- a/recipes/nose
+++ b/recipes/nose
@@ -1,1 +1,1 @@
-(nose :fetcher hg :url "https://bitbucket.org/durin42/nosemacs")
+(nose :fetcher bitbucket :repo "durin42/nosemacs")

--- a/recipes/ob-axiom
+++ b/recipes/ob-axiom
@@ -1,3 +1,3 @@
-(ob-axiom :fetcher hg
-          :url "https://bitbucket.org/pdo/axiom-environment"
+(ob-axiom :fetcher bitbucket
+          :repo "pdo/axiom-environment"
           :files ("ob-axiom.el"))

--- a/recipes/openwith
+++ b/recipes/openwith
@@ -1,3 +1,3 @@
 (openwith
- :fetcher hg
- :url "https://bitbucket.org/jpkotta/openwith")
+ :fetcher bitbucket
+ :repo "jpkotta/openwith")

--- a/recipes/per-buffer-theme
+++ b/recipes/per-buffer-theme
@@ -1,1 +1,1 @@
-(per-buffer-theme :fetcher hg :url "https://bitbucket.org/inigoserna/per-buffer-theme.el")
+(per-buffer-theme :fetcher bitbucket :repo "inigoserna/per-buffer-theme.el")

--- a/recipes/pmdm
+++ b/recipes/pmdm
@@ -1,1 +1,1 @@
-(pmdm :fetcher hg :url "https://bitbucket.org/inigoserna/pmdm.el")
+(pmdm :fetcher bitbucket :repo "inigoserna/pmdm.el")

--- a/recipes/project-root
+++ b/recipes/project-root
@@ -1,3 +1,3 @@
-(project-root :fetcher hg
-              :url "https://bitbucket.org/piranha/project-root"
+(project-root :fetcher bitbucket
+              :repo "piranha/project-root"
               :files ("project-root.el"))

--- a/recipes/pydoc-info
+++ b/recipes/pydoc-info
@@ -1,1 +1,1 @@
-(pydoc-info :fetcher hg :url "https://bitbucket.org/jonwaltman/pydoc-info")
+(pydoc-info :fetcher bitbucket :repo "jonwaltman/pydoc-info")

--- a/recipes/pylint
+++ b/recipes/pylint
@@ -1,4 +1,4 @@
 (pylint
- :url "https://bitbucket.org/logilab/pylint"
- :fetcher hg
+ :repo "logilab/pylint"
+ :fetcher bitbucket
  :files ("elisp/pylint.el"))

--- a/recipes/syntax-subword
+++ b/recipes/syntax-subword
@@ -1,3 +1,3 @@
 (syntax-subword
- :fetcher hg
- :url "https://bitbucket.org/jpkotta/syntax-subword")
+ :fetcher bitbucket
+ :repo "jpkotta/syntax-subword")

--- a/recipes/toxi-theme
+++ b/recipes/toxi-theme
@@ -1,1 +1,1 @@
-(toxi-theme :fetcher hg :url "http://bitbucket.org/postspectacular/toxi-theme")
+(toxi-theme :fetcher bitbucket :repo "postspectacular/toxi-theme")

--- a/recipes/unicode-input
+++ b/recipes/unicode-input
@@ -1,1 +1,1 @@
-(unicode-input :fetcher hg :url "https://bitbucket.org/m00nlight/unicode-input/")
+(unicode-input :fetcher bitbucket :repo "m00nlight/unicode-input")

--- a/recipes/wisp-mode
+++ b/recipes/wisp-mode
@@ -1,1 +1,1 @@
-(wisp-mode :fetcher hg :url "https://bitbucket.org/ArneBab/wisp")
+(wisp-mode :fetcher bitbucket :repo "ArneBab/wisp")


### PR DESCRIPTION
defaults to using `hg` since thats what bitbucket is mostly used for. bitbucket.com can also do git and the recipes using bitbucket.com+git (aria2, ert-junit, igv, jack-connect) still work.
