### PR TITLE
Remove flycheck-processing

### DIFF
--- a/recipes/flycheck-processing
+++ b/recipes/flycheck-processing
@@ -1,4 +1,0 @@
-(flycheck-processing
- :repo "ptrv/processing2-emacs"
- :fetcher github
- :files ("flycheck-processing.el"))


### PR DESCRIPTION
The Flycheck syntax checker for processing has become part of Flycheck itself, see flycheck/flycheck#812 and https://github.com/ptrv/processing2-emacs/issues/11.  /cc @ptrv