### PR TITLE
w3m: fetch from GitHub

### DIFF
--- a/recipes/w3m
+++ b/recipes/w3m
@@ -1,4 +1,3 @@
-(w3m :url ":pserver:anonymous@cvs.namazu.org:/storage/cvsroot"
-     :module "emacs-w3m"
-     :fetcher cvs
+(w3m :repo "emacsmirror/w3m"
+     :fetcher github
      :files (:defaults "icons" (:exclude "octet.el" "mew-w3m.el" "w3m-xmas.el")))


### PR DESCRIPTION
The original anonymous CVS repository is very unreliable. Notably, the `shimbun` package from the same repository was already using `emacswirror/w3m`.