### PR TITLE
cdb: fetch from GitHub

### DIFF
--- a/recipes/cdb
+++ b/recipes/cdb
@@ -1,5 +1,3 @@
-(cdb
- :url ":pserver:guest:guest@openlab.jp:/circus/cvsroot"
- :module "skk/main"
- :fetcher cvs
- :files ("cdb.el"))
+(cdb :repo "skk-dev/ddskk"
+     :fetcher github
+     :files ("cdb.el"))


### PR DESCRIPTION
The anonymous CVS repository is very unreliable. The `ddskk` package from the same repository was already using GitHub.