### PR TITLE
remove deprecated smart-operator

### DIFF
--- a/recipes/electric-spacing
+++ b/recipes/electric-spacing
@@ -1,3 +1,4 @@
 (electric-spacing
  :fetcher github
- :repo "xwl/electric-spacing")
+ :repo "xwl/electric-spacing"
+ :old-names (smart-operator))

--- a/recipes/smart-operator
+++ b/recipes/smart-operator
@@ -1,1 +1,0 @@
-(smart-operator :fetcher wiki)


### PR DESCRIPTION
`electric-spacing` is the successor.
See https://github.com/xwl/smart-operator/issues/3.