### PR TITLE
remove puppetfile-mode

### DIFF
--- a/recipes/puppetfile-mode
+++ b/recipes/puppetfile-mode
@@ -1,4 +1,0 @@
-(puppetfile-mode
- :fetcher github
- :repo "ssm/elisp"
- :files ("puppetfile-mode.el"))


### PR DESCRIPTION
According to its author this mode is redundant, ruby-mode should
be used instead.  See https://github.com/ssm/elisp/issues/2.