### PR TITLE
remove seq

### DIFF
--- a/recipes/seq
+++ b/recipes/seq
@@ -1,1 +1,0 @@
-(seq :fetcher github :repo "NicolasPetton/seq.el")


### PR DESCRIPTION
The version in GNU Elpa and Nicolas' Github repository is a backport for
users of Emacsen before v25.  It's version currently is v1.11, while the
version in Emacs emacs-25 branch is 2.3.  This assures that users of v25
do not accidentally install the backport.

This package has to be removed from Melpa because it uses timestamps as
version numbers and those are always higher than the version number of
the built-in version, which would result in v25 users installing the
version intended for users of v24 and earlier.

https://github.com/milkypostman/melpa/issues/3383#issuecomment-164376009