### PR TITLE
New recipe for xquery-tool.

### DIFF
--- a/recipes/xquery-tool
+++ b/recipes/xquery-tool
@@ -1,0 +1,1 @@
+(xquery-tool :fetcher github :repo "paddymcall/xquery-tool.el")


### PR DESCRIPTION
xquery-tool (https://github.com/paddymcall/xquery-tool.el) is supposed to be a very simplistic interface to saxonb's xquery things. Mainly useful for running simple xpath queries.

I wrote this package.