### PR TITLE
Change diminish repository to the new official one

### DIFF
--- a/recipes/diminish
+++ b/recipes/diminish
@@ -1,1 +1,1 @@
-(diminish :fetcher github :repo "emacsmirror/diminish")
+(diminish :fetcher github :repo "myrjola/diminish.el")


### PR DESCRIPTION
I have taken over maintainership of diminish after a private mail conversation with the original author Will Mengarini. The official repository is now https://github.com/myrjola/diminish.el. I have also notified Emacsmirror about this change https://github.com/emacsmirror/p/issues/67#issuecomment-164792676.