### PR TITLE
Repository moved to emacs-eclim organization.

### DIFF
--- a/recipes/emacs-eclim
+++ b/recipes/emacs-eclim
@@ -1,4 +1,4 @@
 (emacs-eclim
  :fetcher github
- :repo "senny/emacs-eclim"
+ :repo "emacs-eclim/emacs-eclim"
  :files ("*.el" "snippets"))


### PR DESCRIPTION
The emacs-eclim organization is a GitHub organization and was created on
December 16, 2005. The previous project owner was [senny/emacs-eclim](https://github.com/senny/emacs-eclim).