### PR TITLE
Add vhdl-tools

### DIFF
--- a/recipes/vhdl-tools
+++ b/recipes/vhdl-tools
@@ -1,0 +1,1 @@
+(vhdl-tools :repo "csantosb/vhdl-tools" :fetcher github)


### PR DESCRIPTION
Package to navigate a project containing vhdl sources, fork of `vhdl-goto-ref`, from where I add the functions I currently use.