### PR TITLE
Adding html-frag-checker

### DIFF
--- a/recipes/html-check-frag
+++ b/recipes/html-check-frag
@@ -1,0 +1,1 @@
+(html-check-frag :repo "TobiasZawada/html-check-frag" :fetcher github)


### PR DESCRIPTION
This nifty little module was written by Tobias to solve http://stackoverflow.com/questions/19363837/how-can-i-highlight-unmatched-html-tags-in-emacs

![html_check_frag](https://cloud.githubusercontent.com/assets/70800/11954613/d2ea596c-a8a1-11e5-8748-9a17db281d69.png)
