### PR TITLE
Add org-ref.org and citeproc dir to the recipe

### DIFF
--- a/recipes/org-ref
+++ b/recipes/org-ref
@@ -1,1 +1,1 @@
-(org-ref :fetcher github :repo "jkitchin/org-ref")
+(org-ref :fetcher github :repo "jkitchin/org-ref" :files ("*.el" "org-ref.org" "citeproc/*.el"))

--- a/recipes/org-ref
+++ b/recipes/org-ref
@@ -1,1 +1,1 @@
-(org-ref :fetcher github :repo "jkitchin/org-ref" :files ("*.el" "org-ref.org" "citeproc/*.el"))
+(org-ref :fetcher github :repo "jkitchin/org-ref" :files (:defaults "org-ref.org" "citeproc))

--- a/recipes/org-ref
+++ b/recipes/org-ref
@@ -1,1 +1,1 @@
-(org-ref :fetcher github :repo "jkitchin/org-ref" :files (:defaults "org-ref.org" "citeproc"))
+(org-ref :fetcher github :repo "jkitchin/org-ref" :files (:defaults "org-ref.org" "citeproc" "citeproc/readme.org"))

--- a/recipes/org-ref
+++ b/recipes/org-ref
@@ -1,1 +1,1 @@
-(org-ref :fetcher github :repo "jkitchin/org-ref" :files (:defaults "org-ref.org" "citeproc))
+(org-ref :fetcher github :repo "jkitchin/org-ref" :files (:defaults "org-ref.org" "citeproc"))

--- a/recipes/org-ref
+++ b/recipes/org-ref
@@ -1,1 +1,1 @@
-(org-ref :fetcher github :repo "jkitchin/org-ref" :files (:defaults "org-ref.org" "citeproc" "citeproc/readme.org"))
+(org-ref :fetcher github :repo "jkitchin/org-ref" :files (:defaults "org-ref.org" "citeproc"))


### PR DESCRIPTION
org-ref.org is a help file/manual for org-ref. The citeproc directory contains a citation processor for non-latex exports.