### PR TITLE
Add recipe for import-js

### DIFF
--- a/recipes/import-js
+++ b/recipes/import-js
@@ -1,0 +1,3 @@
+(import-js :repo "trotzig/import-js"
+           :fetcher github
+           :files ("plugin/import-js.el"))


### PR DESCRIPTION
import-js is a tool originally developed by @trotzig to automatically
manage Javascript imports in Vim. We have been working on extending the
tool to Emacs, with common base code. The repo for import-js can be
found here:
https://github.com/trotzig/import-js

The code for Emacs is at:
https://github.com/trotzig/import-js/blob/master/plugin/import-js.el

import-js.el adds functions for starting a ruby process that handles the
imports, and two main functions for interaction:

1. import-js-import
   The import function adds the related JS module to your file's
   requires

2. import-js-goto
   Opens the module currently under the cursor, allowing you to easily
   jump to the file defining that module.