### PR TITLE
Add go-playground-cli recipe

### DIFF
--- a/recipes/go-playground-cli
+++ b/recipes/go-playground-cli
@@ -1,0 +1,3 @@
+(go-playground-cli :repo "kosh04/emacs-go-playground"
+                   :fetcher github
+                   :files ("go-playground-cli.el"))


### PR DESCRIPTION
It is Go Playground web client tool, unlike go-playground recipe #3175.

go-playground-fmt.el is also implemented, but not need here.