### PR TITLE
bzr: support stable versions

### DIFF
--- a/recipes/weblogger
+++ b/recipes/weblogger
@@ -1,1 +1,4 @@
-(weblogger :fetcher bzr :url "lp:weblogger-el")
+(weblogger
+ :fetcher bzr
+ :url "lp:weblogger-el"
+ :version-regexp "REL\\(.*\\)")


### PR DESCRIPTION
I made changes to `package-build--find-version-newest` to support the bzr convention of writing tags like `REL1_4_5`.  The changes could only lead to trouble if someone had an odd tag like `0_1.2.2` that they expected to be parsed as `(0 -4 1 2 2)`; MELPA would now treat it as `(0 1 -4 2 -4 2)`.

An alternative approach would be to add another key to recipes, specifying the version-separator.