### PR TITLE
Add dired-reuse recipe

### DIFF
--- a/recipes/dired-reuse
+++ b/recipes/dired-reuse
@@ -1,0 +1,1 @@
+(dired-reuse :fetcher github :repo "crocket/dired-reuse")


### PR DESCRIPTION
dired-single has been unmaintained for more than 2 years, and it hasn't moved to github and tagged a version.

dired-single is pretty much dead, and I think we need to start over with a new name.

I renamed it to dired-reuse. Mine has a version tagged, so it will be available on melpa-stable. Melpa packages are too unstable for my tasks.