### PR TITLE
Added CFF recipe

### DIFF
--- a/recipes/cff
+++ b/recipes/cff
@@ -1,0 +1,1 @@
+(cff :fetcher github :repo "fourier/cff")


### PR DESCRIPTION
A simple package to search C/C++ headers file by source file and vice versa in a typical different tree in git/svn repository. Allows to search using simple regexp/rules, like for a **file.cpp** file in **src** directory find the corresponding **file.h/hpp** file in *closest* **inc** directory.