### PR TITLE
Add flycheck-checkbashisms

### DIFF
--- a/recipes/flycheck-checkbashisms
+++ b/recipes/flycheck-checkbashisms
@@ -1,0 +1,1 @@
+(flycheck-checkbashisms :repo "Gnouc/flycheck-checkbashisms" :fetcher github)


### PR DESCRIPTION
Add a flycheck linter for `/bin/sh` script using [checkbashisms](https://anonscm.debian.org/cgit/collab-maint/devscripts.git/tree/scripts/checkbashisms.pl)

Repo: https://github.com/Gnouc/flycheck-checkbashisms