### PR TITLE
Redirect dired-single to crocket/dired-single

### DIFF
--- a/recipes/dired-single
+++ b/recipes/dired-single
@@ -1,1 +1,1 @@
-(dired-single :fetcher wiki)
+(dired-single :fetcher github :repo "crocket/dired-single")


### PR DESCRIPTION
It was originally opened as #3438. `dired-single` has been unmaintained for years. It is time to move the package to github and change the maintainer.