### PR TITLE
Add recipe for key-leap

### DIFF
--- a/recipes/key-leap
+++ b/recipes/key-leap
@@ -1,0 +1,1 @@
+(key-leap :fetcher github :repo "MartinRykfors/key-leap")


### PR DESCRIPTION
Key-leap is a minor mode that populates the margin with a set of n-letter keywords for every visible line in the window. By calling an interactive command followed by the key of a line, the point is moved to that line.

It can be found at https://github.com/MartinRykfors/key-leap, where you can also se a .gif of it in action.

I am the author.