### PR TITLE
Add evil-ediff

### DIFF
--- a/recipes/evil-ediff
+++ b/recipes/evil-ediff
@@ -1,0 +1,1 @@
+(evil-ediff :repo "justbur/evil-ediff" :fetcher github)


### PR DESCRIPTION
evil-ediff is a simple package that adds some vim-like movement commands
to ediff.