### PR TITLE
renamed org-screenshot to org-attach-screenshot

### DIFF
--- a/recipes/org-attach-screenshot
+++ b/recipes/org-attach-screenshot
@@ -1,0 +1,4 @@
+(org-attach-screenshot
+ :fetcher github
+ :repo "dfeich/org-screenshot"
+ :old-names (org-screenshot))

--- a/recipes/org-screenshot
+++ b/recipes/org-screenshot
@@ -1,3 +1,0 @@
-(org-screenshot
- :fetcher github
- :repo "dfeich/org-screenshot")


### PR DESCRIPTION
The old name org-screenshot clashed with a package from
org-plus-contrib (dfeich/org-screenshot#2).