### PR TITLE
add recipe start-menu

### DIFF
--- a/recipes/start-menu
+++ b/recipes/start-menu
@@ -1,0 +1,1 @@
+(start-menu :fetcher github :repo "lujun9972/el-start-menu")


### PR DESCRIPTION
start-menu is a little tool that will add a "Start" menu in the menu bar 
You can use the Start menu to executing external program just like the start menu in windows.
