### PR TITLE
Add caseformat recipe

### DIFF
--- a/recipes/caseformat
+++ b/recipes/caseformat
@@ -1,0 +1,1 @@
+(caseformat :repo "HKey/caseformat" :fetcher github)


### PR DESCRIPTION
Caseformat is a format based letter case converter.
It helps users to insert uppercase alphabetical characters without shift keys.

I'm the author of it.

Repository:
https://github.com/HKey/caseformat