### PR TITLE
Add prompt-text recipe

### DIFF
--- a/recipes/prompt-text
+++ b/recipes/prompt-text
@@ -1,0 +1,1 @@
+(prompt-text :repo "10sr/prompt-text-el" :fetcher github)


### PR DESCRIPTION
Print additional information always when Emacs asks you something via minibuffer.

I'm the maintainer of this package.
https://github.com/10sr/prompt-text-el