### PR TITLE
Updated request-deferred to use new fork

### DIFF
--- a/recipes/request-deferred
+++ b/recipes/request-deferred
@@ -1,1 +1,1 @@
-(request-deferred :repo "tkf/emacs-request" :fetcher github :files ("request-deferred.el"))
+(request-deferred :repo "abingham/emacs-request" :fetcher github :files ("request-deferred.el"))


### PR DESCRIPTION
This is a sibling PR of [the recent update to request](https://github.com/milkypostman/melpa/pull/3461). It seems smart to keep both the request and request-deferred recipes using the same source repo.