### PR TITLE
Add worse-defaults

### DIFF
--- a/recipes/worse-defaults
+++ b/recipes/worse-defaults
@@ -1,0 +1,2 @@
+(worse-defaults :fetcher github :repo "hydandata/worse-defaults")
+


### PR DESCRIPTION
Things in this package represent better (worse?) default settings for
many things that Emacs ships with.

This defaults are also somewhat opinionated, which might not be
acceptable for everyone, hence `worse` in the title.

##### What is included?

In short, a lot. This is definitely not one of those minimalist packages
that try to find the golden middle between sensible and practical, use
`better-defaults` if you prefer something like that.

A convenience function `goto-matching-paren` is also provided, it is bound
to `C-c {`.