### PR TITLE
include elm.tags file with elm-mode

### DIFF
--- a/recipes/elm-mode
+++ b/recipes/elm-mode
@@ -1,1 +1,4 @@
-(elm-mode :fetcher github :repo "jcollard/elm-mode")
+(elm-mode
+ :fetcher github
+ :repo "jcollard/elm-mode"
+ :files (:defaults "elm.tags"))


### PR DESCRIPTION
I added automatic TAGS generation based on a list of regular expressions to elm-mode this morning, I ended up using a separate file for the tags' regexps so that needs to be included with the package for the functionality to work.