### PR TITLE
Please add recipes/sly-hello-world

### DIFF
--- a/recipes/sly-hello-world
+++ b/recipes/sly-hello-world
@@ -1,0 +1,5 @@
+(sly-hello-world :fetcher github
+                 :repo "capitaomorte/sly-hello-world"
+                 :files (:defaults
+                         "*.lisp"
+                         "*.asd"))


### PR DESCRIPTION
As a package it doesn't really do anything special for SLY, except teaching would-be contrib writers how it works. I tested with

```
make recipes/sly-hello-world
make sandbox
M-x package-install sly-hello-world RET ; this brings in sly as well
M-x sly ; SLY is already hello-world enabled
```