### PR TITLE
new recipe 'zone-select'.

### DIFF
--- a/recipes/zone-select
+++ b/recipes/zone-select
@@ -1,0 +1,2 @@
+(zone-select :repo "kawabata/zone-select"
+             :fetcher github)


### PR DESCRIPTION
Current emacs 'play/zone.el' does not provide the features of selecting, previewing, adding or removing zone programs from 'zone-programs' variable.  This code provides such features.
