### PR TITLE
Set git repo to SourceForge.

### DIFF
--- a/recipes/log4j-mode
+++ b/recipes/log4j-mode
@@ -1,1 +1,4 @@
-(log4j-mode :fetcher github :repo "emacsorphanage/log4j-mode")
+(log4j-mode
+ :fetcher git
+ :url "git://git.code.sf.net/p/log4j-mode/code"
+ :files ("src/*.el"))


### PR DESCRIPTION
Hi!

I am the author of package log4j-mode which currently is fetched from emacsorphanage. Now, I have created a git repo for this package over at SourceForge. I have also added some new functionality which I would like published.

I have modified the recipe for log4j-mode so it looks like the onefor my other package, jtags. However, I have not managed to install a locally built package using this recipe. On the other hand, I cannot build and install jtags locally either, but it seems to work fine on your server. The error message I get is that the package is missing a Version or Package-version header though it clearly has one.

The git repo is found at: git://git.code.sf.net/p/log4j-mode/code.

I would appreciate any help on how to proceed. It would also be fine with me if you did the recipe change.

Best regards,

Johan Dykström