### PR TITLE
Add recipe for mutant

### DIFF
--- a/recipes/mutant
+++ b/recipes/mutant
@@ -1,0 +1,1 @@
+(mutant :fetcher github :repo "p-lambert/mutant.el")


### PR DESCRIPTION
This package provides an interface for dealing with the [Mutant](https://github.com/mbj/mutant) testing tool, enabling one to easily launch it from a `.rb` file or even from a `dired` buffer. The generated output is nicely formatted and provides direct links to the errors reported by the mutations. I've tried to mimic the `rspec-mode` overall experience as much as possible.

**Link to the repository**: [mutant.el](https://github.com/p-lambert/mutant.el)