### PR TITLE
Add ‘avy-menu’ package

### DIFF
--- a/recipes/avy-menu
+++ b/recipes/avy-menu
@@ -1,0 +1,1 @@
+(avy-menu :repo "mrkkrp/avy-menu" :fetcher github)


### PR DESCRIPTION
Abstracted menu that is used in my older package `ace-popup-menu` so it can be used with other packages as well. Once this is in MELPA, I will make `ace-popup-menu` and one more upcoming package depend on `avy-menu`.

Link to the repo: https://github.com/mrkkrp/avy-menu