### PR TITLE
Add recipe for evalator

### DIFF
--- a/recipes/evalator
+++ b/recipes/evalator
@@ -1,0 +1,2 @@
+(evalator :fetcher github
+          :repo "seanirby/evalator")


### PR DESCRIPTION
I'm the author of [Evalator](https://github.com/seanirby/evalator) and I'd like to add it to MELPA.  

Evalator is a package for interactive REPL-like evaluation within emacs, plus more.  The idea is that you can try out code like a REPL but results are remembered for subsequent transformation.  You can also send results to elisp commands and functions, even if you used a language other than elisp to generate them.  Evalator uses helm to automatically display results in a helm buffer. 

Evalator comes with an elisp evaluation context, and that is the default, but it is designed to be extended with other context packages.  If I get this into MELPA I will also be submitting this [package](https://github.com/seanirby/evalator-context-cider) to add clojure support to evalator 

Regarding the name,  I suspect you'll want me to add the helm- prefix to it.  I'm certainly open to doing that, but I chose not because it's not used for narrowing a list, which is the typical helm use case.  Let me know what you think.
