### PR TITLE
add tar-util.el and exclude skk-lookup.el

### DIFF
--- a/recipes/ddskk
+++ b/recipes/ddskk
@@ -2,5 +2,5 @@
  :repo "skk-dev/ddskk"
  :fetcher github
  :old-names (skk)
- :files ("context-skk.el" "ddskk*.el" "skk*.el" "doc/skk.texi" "etc/skk.xpm"
-         (:exclude "skk-xemacs.el")))
+ :files ("context-skk.el" "ddskk*.el" "skk*.el" "tar-util.el" "doc/skk.texi" "etc/skk.xpm"
+         (:exclude "skk-xemacs.el" "skk-lookup.el")))


### PR DESCRIPTION
I am one of maintainer of ddskk. https://github.com/skk-dev/ddskk
new file tar-utile.el was added.
and skk-lookup.el is excluded at this version of ddskk. 