### PR TITLE
magit: exclude file using full path

### DIFF
--- a/recipes/magit
+++ b/recipes/magit
@@ -5,4 +5,4 @@
                "Documentation/magit.texi"
                "Documentation/AUTHORS.md"
                "COPYING"
-               (:exclude "magit-popup.el")))
+               (:exclude "lisp/magit-popup.el")))


### PR DESCRIPTION
because otherwise it's not being excluded at all.