### PR TITLE
Add recipe for dired-atool

### DIFF
--- a/recipes/dired-atool
+++ b/recipes/dired-atool
@@ -1,0 +1,1 @@
+(dired-atool :repo "HKey/dired-atool" :fetcher github)


### PR DESCRIPTION
Dired-atool is an utility to pack/unpack files with [atool](http://www.nongnu.org/atool/) on dired.
This provides some command to call atool.

I'm the author of it, the repository is https://github.com/HKey/dired-atool.