### PR TITLE
remove otter-mode

### DIFF
--- a/recipes/otter-mode
+++ b/recipes/otter-mode
@@ -1,1 +1,0 @@
-(otter-mode :fetcher github :repo "scvalex/script-fu" :files ("otter-mode.el"))


### PR DESCRIPTION
The library has been [removed from the upstream repository](https://github.com/scvalex/script-fu/commit/712b2e3ed9ad56570cde7d824ab5a7b11874772d)

There is also [an older `otter-mode`](https://github.com/schaueho/otter-mode). Maybe that should be added to Melpa instead. @schaueho wrote it two decades ago and hasn't really touched it since then.