### PR TITLE
org-random-todo

### DIFF
--- a/recipes/org-random-todo
+++ b/recipes/org-random-todo
@@ -1,0 +1,3 @@
+(org-random-todo :fetcher github
+                 :repo "unhammer/org-random-todo"
+                 :files ("org-random-todo.el"))


### PR DESCRIPTION
Summary: Shows a random TODO from your org-agenda-files (or other list)
every so often, using message (and optionally notifications-notify).

Link: https://github.com/unhammer/org-random-todo

Association: Author.