### PR TITLE
Add recipe for search-files

### DIFF
--- a/recipes/search-files
+++ b/recipes/search-files
@@ -1,0 +1,2 @@
+(search-files :repo "dandavison/emacs-search-files"
+              :fetcher github)


### PR DESCRIPTION
Tested by following the instructions in the melpa README:

- `make clean` && `make recipes/search-files`
- `EMACS=$(which emacs) make sandbox`
- `(package-list-packages)` => select "search-files" and use buttons to install

https://github.com/dandavison/emacs-search-files