### PR TITLE
Add latex-unicode-math-mode

### DIFF
--- a/recipes/latex-unicode-math-mode
+++ b/recipes/latex-unicode-math-mode
@@ -1,0 +1,4 @@
+(latex-unicode-math-mode
+ :repo "Christoph-D/latex-unicode-math-mode"
+ :fetcher github
+ :files (:defaults "*.sty"))


### PR DESCRIPTION
[latex-unicode-math-mode](https://github.com/Christoph-D/latex-unicode-math-mode) is a minor mode that allows the user to enter Unicode symbols in LaTeX math environments. For example, it replaces `\phi` with `φ` and `==` with `≡`.

Compared to the `TeX` input method it has more convenient keybindings and a .sty file to compile the resulting .tex file with pdflatex