### PR TITLE
add omtose-phellack-theme

### DIFF
--- a/recipes/omtose-phellack-theme
+++ b/recipes/omtose-phellack-theme
@@ -1,0 +1,1 @@
+(omtose-phellack-theme :fetcher github :repo "franksn/omtose-phellack-theme")


### PR DESCRIPTION
[Omtose-phellack](https://github.com/franksn/omtose-phellack-theme)  is just another dark bluish theme for emacs. For both the gui and the terminal (WIP). 

I am the author.