### PR TITLE
Local declarative programming with Org elements.

### DIFF
--- a/recipes/org-dp
+++ b/recipes/org-dp
@@ -1,0 +1,5 @@
+(org-dp
+ :fetcher github
+ :url "https://github.com/tj64/org-dp"
+ :repo "tj64/org-dp"
+ :files ("org-dp.el"))

--- a/recipes/org-dp
+++ b/recipes/org-dp
@@ -1,5 +1,1 @@
-(org-dp
- :fetcher github
- :url "https://github.com/tj64/org-dp"
- :repo "tj64/org-dp"
- :files ("org-dp.el" "org-dp-lib.el"))
+(org-dp :fetcher github :repo "tj64/org-dp")

--- a/recipes/org-dp
+++ b/recipes/org-dp
@@ -2,4 +2,4 @@
  :fetcher github
  :url "https://github.com/tj64/org-dp"
  :repo "tj64/org-dp"
- :files ("org-dp.el"))
+ :files ("org-dp.el" "org-dp-lib.el"))

--- a/recipes/org-dp-lib
+++ b/recipes/org-dp-lib
@@ -1,5 +1,0 @@
-(org-dp-lib
- :fetcher github
- :url "https://github.com/tj64/org-dp"
- :repo "tj64/org-dp"
- :files ("org-dp-lib.el"))

--- a/recipes/org-dp-lib
+++ b/recipes/org-dp-lib
@@ -1,0 +1,5 @@
+(org-dp-lib
+ :fetcher github
+ :url "https://github.com/tj64/org-dp"
+ :repo "tj64/org-dp"
+ :files ("org-dp-lib.el"))


### PR DESCRIPTION
org-dp (https://github.com/tj64/org-dp) is meant for local programming,
i.e. for situations where the complete parse tree of an Org-mode file is
not needed, but the focus is on the Org element at point.

It leaves parsing and interpreting to the Org-mode parser framework and
creates, updates and deletes Org elements by acting on their uniform
internal (p-list) representations rather than on their diverse textual
representations.

I'm the library's only author and maintainer.