### PR TITLE
remove midje-test-mode

### DIFF
--- a/recipes/midje-test-mode
+++ b/recipes/midje-test-mode
@@ -1,1 +1,0 @@
-(midje-test-mode :fetcher github :repo "bpoweski/midje-test-mode")


### PR DESCRIPTION
`midje-test-mode.el` requires `clojure-test-mode` which
was removed from `clojure-mode` more than a year ago.

https://github.com/clojure-emacs/clojure-mode/commit/c7f762976d4147d36b89133c5d9b93accfc9e898